### PR TITLE
native recompilation progress

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,3 +23,22 @@ ctest --test-dir build -C Release --output-on-failure
 ## Why there is no full game build command
 
 The complete integration build consumes private, legally owned inputs and generates derived C++ translation units that are not part of this public repository. Publishing a command that appears to produce a game from missing data would be misleading. A future release workflow will accept user-supplied inputs locally and keep them outside version control.
+
+## Verify the course lookup recovery
+
+The source-safe utility below checks two ISO9660-truncated course files directly
+inside a user-owned GDS-0033 dump and matching security PIC. It can verify the
+inputs without writing anything:
+
+```bash
+python tools/prepare_v1023_course_lookup_hostfs.py \
+  --base-drivea /path/to/private/driveA_v1022 \
+  --tools /path/to/private/extraction-tools \
+  --bin /path/to/user-owned/gds-0033.bin \
+  --pic /path/to/user-owned/317-0384-com.pic \
+  --verify-only
+```
+
+To create a new private HOSTFS overlay, replace `--verify-only` with
+`--output-drivea /path/to/private/driveA_v1023`. The tool refuses to overwrite
+an existing output and verifies the exact source extents, sizes, and hashes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v2018-wip — 2026-08-18
+
+- Advanced the private static-AOT runtime beyond the earlier submitted-stream lifecycle blocker into sustained native Naomi 2 scene presentation.
+- Added focused native validation for AICA SGC/mailbox behavior, Maple VBlank/reset, system-ROM protection, JVS behavior, and PVR texture layout.
+- Traced alternating rainbow/static environment maps to two missing ISO9660-truncated course lookup files rather than the 30/60 FPS presentation cap.
+- Added a source-safe, hash-checked preparation tool that restores those logical files from user-owned inputs without redistributing game data.
+- Validated a coherent native Trueno camera sequence with a 60 FPS presentation target.
+- Kept the current limitation explicit: the diagnostic renderer does not yet sustain 60 unique frames per second, and a complete controllable race is not yet proven.
+
 ## v1335-wip — 2026-08-15
 
 - Packaged a source-safe public progress repository.

--- a/README.md
+++ b/README.md
@@ -10,25 +10,27 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
-## What works today
+## What works today (2026-08-18)
 
 - A Python SH-4 decoder/code generator covers the instruction families exercised by the current static-AOT path, including FPSCR-aware floating-point register width and bank handling.
-- Native C++ execution reaches deterministic boot/attract-mode replay checkpoints with direct translated-function dispatch and no interpreter or JIT fallback.
-- A clean-room ELAN command decoder and diagnostic renderer reproduce about 53 seconds of the intro's 3D cinematography: shot changes, animated lighting, multiple cars, and the two-car chase sequence.
+- Native C++ execution cold-boots into sustained attract-mode rendering with direct translated-function dispatch and no interpreter or JIT fallback.
+- The submitted ELAN stream, CH2 DMA, render-complete interrupts, retained scenes, and native presentation path now advance continuously instead of stalling at the earlier frame-lifecycle frontier.
+- The Naomi 2 renderer handles the observed opaque, translucent, modifier-volume, punch-through, fog, blend, texture, and user-tile-clip cases used by the current scenes.
+- A missing course environment/path lookup was traced to two ISO9660-truncated files. A source-safe tool now restores their logical names from a user's own dump and verifies exact hashes.
+- A corrected native sequence renders a single coherent textured Trueno with stable camera motion at a 60 FPS presentation target; the earlier alternating rainbow/static environment maps are gone.
 - Cross-machine N70 validation reproduced an identical rendered-frame SHA-256: `34D6B91C0550A5CC2A60D4B1F8930812908CEA6DCD6C354749A0881BE426D9E2`.
-- Narrow device seams exist for ELAN command classification, JVS I/O, and the AICA bootstrap handshake.
-- The current v1335 work-in-progress recognizes all five observed ELAN `RegisterWait` list-complete masks, with a focused Windows test passing.
+- Private integration tests cover ELAN command/VRAM classification, JVS identity and EEPROM behavior, Maple VBlank/reset behavior, Naomi system-ROM write protection, Flycast-derived AICA SGC/mailbox behavior, and PVR twiddled texture layout.
 
 ![Intro shot progression](docs/media/native-intro-strip.png)
 
 ## What does not work yet
 
 - The result is not a start-to-finish playable build.
-- Submitted ELAN `Link` streams still need a bounded native walk so embedded `RegisterWait` records execute at the real command boundary.
-- The frame lifecycle currently stalls around stage 112 on the new native submission path; acceptance requires real waits, CH2 DMA kicks, request-slot completion, and producer progress.
-- Plain PVR/TA 2D lists are not yet composited over ELAN 3D, so title/logo cards and several overlays are missing.
-- Audio beyond the bootstrap-ready seam, complete controls, whole-game coverage, and presentation polish remain incomplete.
-- Some sky/road texture evidence depends on private pre-capture state and must never be fabricated or redistributed.
+- A complete controllable race has not yet been reached and validated end to end.
+- The entire intro/menu/course-loading sequence still needs frame-by-frame correctness checks; later texture, depth, transparency, shadow, fog, overlay, and camera issues may remain.
+- The current diagnostic renderer does not consistently sustain 60 unique rendered frames per second and still needs profiling and optimization.
+- Complete cabinet controls, synchronized game audio, whole-game static-AOT coverage, long-run determinism, and presentation polish remain incomplete.
+- The public repository deliberately omits private generated game code, captures, and all legally restricted inputs, so it is not a standalone game build.
 
 See [STATUS.md](STATUS.md) for the evidence ledger and [ROADMAP.md](ROADMAP.md) for ordered acceptance criteria.
 
@@ -39,7 +41,10 @@ See [STATUS.md](STATUS.md) for the evidence ledger and [ROADMAP.md](ROADMAP.md) 
 - `tests/` — public tests that require no game data.
 - `docs/` — architecture, media, and validation notes.
 
-The renderer snapshot is included to show the real integration work, but the complete private runtime and generated translation units are intentionally absent. It is therefore not a standalone game build target.
+The renderer snapshot is included to show the real integration work, while the
+complete private runtime and generated translation units remain intentionally
+absent. The new preparation utility also contains no game data: it operates
+only on user-supplied legally owned inputs.
 
 ## Run the public checks
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,56 +2,53 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## P0 — Execute the submitted ELAN link stream
+## P0 — Reach and control the first complete race
 
-- Add a bounded walk at the existing native ELAN command-port seam.
-- Follow only validated link shapes and ranges.
-- Route embedded `RegisterWait` records through the existing classifier.
-- Reject unknown/empty wait masks and malformed/cyclic links fail-closed.
+- Complete the intro, menu, course-loading, race, results, and return transitions.
+- Remove any remaining static-AOT target gaps, stalls, or device-handshake blockers on that path.
+- Prove steering, accelerator, brake, gears, buttons, coin/service, and race timers together.
 
-Acceptance: the exact v1334 configuration records nonzero waits and no new unimplemented commands, memory faults, crashes, or watchdogs.
+Acceptance: a user can cold boot from legally owned inputs, enter a race, drive,
+finish or exit, and return through the native static path without an
+interpreter/JIT fallback.
 
-## P0 — Close the frame-lifecycle handshake
+## P0 — Validate the complete rendered sequence
 
-- Prove native CH2-to-ELAN DMA kicks.
-- Observe request slot 0 transition from `2` to `0`.
-- Advance the producer beyond frame 1.
-- Preserve both CLX normal-status banks and advance `TA_ITP_CURRENT` per active wait.
+- Capture bounded intro/menu/race sequences from the recomp and reference implementation.
+- Locate the first divergent frame rather than judging isolated screenshots.
+- Fix texture mapping, projection/clipping, depth/order, transparency, shadows, fog, overlays, and camera state from guest-submitted data.
+- Audit other cars, courses, weather, and day/night conditions.
 
-Acceptance: repeated exact runs pass N/N with `unimplemented=0`, `FPSCR=0`, stable provenance, and the accepted N70 frame hash when compatibility gates are off.
+Acceptance: repeatable sequence comparisons show coherent geometry and materials
+without duplicated objects, fabricated textures, or manual replacement frames.
 
-## P1 — Activate TA/PVR list execution and compositing
+## P1 — Complete timing, audio, and controls
 
-- Execute captured opaque, punch-through, translucent, modifier-volume, and sprite lists.
-- Composite TA/PVR 2D output over ELAN 3D at the real frame boundary.
-- Preserve list ordering and interrupt timing.
+- Keep guest timing independent from the host presentation cap.
+- Complete synchronized music, engine, voice, effect, and looping behavior.
+- Validate JVS analog ranges, dead zones, gears, buttons, coin/service, and outputs.
 
-Acceptance: title/logo cards and cabinet overlays appear from guest-submitted data, with no fabricated textures or manual replacements.
+Acceptance: gameplay behaves consistently at different host presentation targets
+with synchronized sound and complete cabinet controls.
 
-## P1 — Restore faithful textures and materials
+## P1 — Sustain the 60 FPS presentation target
 
-- Trace missing game-driven uploads from legally owned private inputs.
-- Validate sky, road, alpha, palette, mip, and blend cases.
-- Continue reference comparisons without embedding reference video or extracted assets.
+- Profile rasterization, texture decode/cache use, scene retention, and memory copies.
+- Optimize only after correctness gates protect the output.
+- Preserve deterministic results across worker counts and machines.
 
-Acceptance: repeatable frame diffs show the renderer—not a diagnostic substitution—producing the expected layers.
+Acceptance: release builds sustain 60 unique presented frames per second at the
+baseline resolution on the target PC class without changing guest timing.
 
-## P1 — Complete audio and controls
+## P2 — Whole-game coverage and regression testing
 
-- Replace the AICA ready-only bootstrap seam with the required native audio path.
-- Validate JVS steering, accelerator, brake, buttons, coin/service, and outputs.
-
-Acceptance: controllable attract/menu/gameplay flow with synchronized audio and no input-script dependency.
-
-## P2 — Whole-game static-AOT coverage
-
-- Translate every reachable function/table coherently.
-- Eliminate unresolved indirect targets and compatibility shims.
-- Add race, course, results, continue, save/configuration, and long-run determinism suites.
+- Cover every car, course, mode, results/continue flow, save/configuration path, and long run.
+- Eliminate unresolved indirect targets and compatibility-only diagnostics.
+- Add deterministic public tests for every source-safe subsystem.
 
 Acceptance: cold boot through a complete race and return flow, entirely through the native static path.
 
-## P2 — Productization
+## P2 — Productization and release packaging
 
 - Reproducible build orchestration that accepts only user-supplied legally owned inputs.
 - Clear asset extraction boundary, configuration UI, controller mapping, crash diagnostics, and release packaging.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,21 +1,22 @@
 # Status and evidence ledger
 
-Status date: 2026-08-15
-Public checkpoint: v1335 WIP
+Status date: 2026-08-18
+Public checkpoint: v2018 WIP
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
 
 | Area | Demonstrated | Current limitation |
 |---|---|---|
 | Static SH-4 translation | Broad instruction decoding/code generation; direct translated calls; FPSCR-aware FPU regression tests | Whole-program coverage and every indirect target are not complete |
+| Native boot/runtime | Static translated execution cold-boots and advances sustained native attract-mode scenes | A complete menu-to-race-to-results flow is not yet validated |
 | Deterministic replay | N70 accepted 70/70 with `unimplemented=0`, `FPSCR=0`, no fault/watchdog, and cross-machine identical frame hash | Uses private user-owned replay/input state that cannot be published |
-| ELAN 3D path | Persistent state, recursive links, materials, instances, lighting, textures, culling, depth, and native diagnostic rendering | New submitted-stream lifecycle does not yet complete end to end |
-| Intro visuals | Roughly 53 seconds of ordered 3D cinematography through slice 3200; AE86, FD3S, red rival, shot cuts and chase | 2D title/logo layers absent; texture/material polish remains |
-| TA/PVR 2D | Store-queue traffic and submitted command history have been observed and mapped | Native list execution/compositing is dormant |
-| ELAN completion | Five observed list-complete `RegisterWait` masks classified; both CLX status banks and TA-ITP update behavior covered in the private integration test | Embedded waits inside the submitted `Link` stream are not reaching the handler yet |
-| JVS/input | Clean-room 837-13551 / 315-6149-facing model exists | Complete cabinet controls and full gameplay validation remain |
-| Audio | Narrow opt-in AICA driver-ready bootstrap seam | No complete native AICA/ARM audio path |
-| Distribution | Sanitized source/evidence package with reproducible public tests | No executable game package; users must supply legally owned inputs to a future private build |
+| ELAN 3D path | Submitted links, CH2 DMA, completion interrupts, persistent state, materials, instances, lighting, textures, culling, depth, and retained presentation scenes advance continuously | Whole-intro and gameplay correctness still need systematic comparison |
+| PVR rendering | Native handling exists for observed opaque/translucent lists, fog, modifier volumes, punch alpha, blend modes, texture layouts, autosort, and tile clipping | Remaining overlays and rejected/projected geometry need scene-by-scene validation |
+| Course environment maps | Missing logical lookup paths were recovered from two exact user-owned ISO files; rainbow/static maps are corrected | Other courses and weather conditions are not yet audited |
+| JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, and keyboard-facing seams pass focused tests | Steering, pedals, gears, buttons, coin/service, and full race control remain to be proven together |
+| Audio | Flycast-derived AICA SGC and mailbox protocol tests pass; the exact driver can be loaded from the private HOSTFS | Complete music, engine, voice, effects, looping, and synchronization remain incomplete |
+| Performance | A coherent sequence survives a 60 FPS presentation target | The diagnostic renderer does not yet sustain 60 unique frames per second |
+| Distribution | Sanitized source/evidence package and user-owned-input preparation tool | No executable game package; private inputs and generated game code remain excluded |
 
 ## Strongest accepted evidence
 
@@ -26,9 +27,17 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 
 ## Latest WIP truth
 
-v1335 broadened direct `RegisterWait` handling for masks `0x80`, `0x100`, `0x200`, `0x400`, and `0x200000`. The focused private Windows integration test passed. An exact fast WSL rebuild was stopped cleanly at the user's request, so the full gate-off and stage-112 acceptance runs have not been completed.
+The earlier linked-stream/frame-lifecycle blocker is no longer the active
+frontier. The current native run advances thousands of guest scene frames and
+presents retained Naomi 2 scenes continuously.
 
-The preceding v1334 trace reported `register_waits=0`. That means the change must not be described as fixing the lifecycle blocker. The best current explanation is that the next frame arrives as a linked command stream and its embedded waits are never walked to the existing handler.
+The latest visual root cause was external asset preparation: two logical course
+lookup names were absent because their ISO9660 physical names are truncated.
+The null table pointer made the guest compositor read unrelated low-memory bytes
+as selectors. Restoring the two exact files from the user's own dump changed
+the invalid selector record to the expected course record and removed the
+alternating rainbow/static environment maps. This does not imply that all
+graphics or gameplay are complete.
 
 ## Definition of playable
 

--- a/docs/COURSE_LOOKUP_RECOVERY.md
+++ b/docs/COURSE_LOOKUP_RECOVERY.md
@@ -1,0 +1,47 @@
+# Course environment lookup recovery
+
+Status: validated in the private native integration build on 2026-08-18.
+
+## Symptom
+
+Alternating environment maps contained bright rainbow/static pixels while the
+companion maps were coherent dark road/environment textures. Changing the host
+window cap between 30 and 60 FPS did not create or repair the corruption.
+
+## Root cause
+
+The original SH-4 course loader requests these logical paths:
+
+```text
+/driveA/env/k_df1_path_env.bin
+/driveA/path/k_df_sdw.bin
+```
+
+The private HOSTFS did not contain them because the physical ISO9660 Level-1
+names are truncated. The first lookup pointer stayed null, so the guest
+compositor read unrelated low-memory bytes as selector values.
+
+Before recovery, the affected descriptor observed a null table and the invalid
+selector bytes `90,62,04,01`. After restoring the files from the same
+user-owned GDS-0033/PIC pair, it observed a valid table and the course selector
+record `05,00,02,00`.
+
+## Exact source mapping
+
+```text
+/ENV/K_DF1_PA.BIN   extent=0x000002DC -> HOSTFS/env/k_df1_path_env.bin
+/PATH/K_DF_SDW.BIN  extent=0x00000A56 -> HOSTFS/path/k_df_sdw.bin
+```
+
+Both physical files are 16,356 bytes. The public preparation utility verifies
+their complete SHA-256 hashes before writing a new private overlay.
+
+## Result and boundary
+
+The corrected private run produces coherent environment maps and a stable
+single-car camera sequence at both 30 and 60 FPS presentation targets. This
+closes that specific corruption; it does not claim that the complete renderer,
+intro, or game is finished.
+
+No disc image, BIOS, PIC, extracted asset, generated game translation, memory
+snapshot, reference capture, or rendered game frame is included here.

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -9,4 +9,10 @@ These files are selected from the private integration tree to show the real clea
 
 Only `native_elan_bridge.h` is compiled by the standalone public smoke test. The decoder/renderer snapshots refer to support headers in the private integration tree and are included for review, not as a claim that this repository is a complete runtime.
 
+The private integration tree has advanced beyond these selected snapshots with
+continuous submitted-scene presentation, additional PVR list features, native
+AICA/Maple tests, and asset-lineage validation. Those components will be moved
+into this public tree only when they can be separated cleanly from generated
+game code and private captures without weakening the legal boundary.
+
 Generated game translations, memory/device integration, private replay code, asset inputs, and compatibility-only experiments are intentionally excluded.

--- a/tools/prepare_v1023_course_lookup_hostfs.py
+++ b/tools/prepare_v1023_course_lookup_hostfs.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Restore two exact course lookup files from a user-owned GDS-0033 dump.
+
+This utility contains no game data or decryption key. It imports the DIMM ISO
+reader from a user-supplied private tools directory, verifies the exact source
+records, and writes a new private HOSTFS overlay without modifying its input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Asset:
+    physical: str
+    logical: str
+    extent: int
+    size: int
+    digest: str
+
+
+ASSETS = (
+    Asset(
+        "/ENV/K_DF1_PA.BIN",
+        "env/k_df1_path_env.bin",
+        0x000002DC,
+        16_356,
+        "5B57E3AF351D16F11F56414A200211C9CEE4C6E469E3D6FAC535670E990FE12F",
+    ),
+    Asset(
+        "/PATH/K_DF_SDW.BIN",
+        "path/k_df_sdw.bin",
+        0x00000A56,
+        16_356,
+        "6A621D64A07A4643A9F87E00B089643AC305A57FEC35762DF126AB577B059D15",
+    ),
+)
+
+V1022_BUNDLE = {
+    "model/adv_newtitle/adv_newtitle_pol.bin.nz": (
+        672,
+        "B1BEF547C57B6039B4ADE58B81D77FED1A077F3C0439C95EE068B0BA384E9BCB",
+    ),
+    "model/adv_newtitle/adv_newtitle_pol.tbl": (
+        8,
+        "2B6D910BD88DC43D68E3283B89B4134E6423E67F9A459C8B85457254CB69AEF4",
+    ),
+    "model/adv_newtitle/adv_newtitle_tex.bin.nz": (
+        557_056,
+        "2E2BA7A6EDB13F708942A087E589C22E12FECE15031D4CFA44512A0F0908E9C4",
+    ),
+    "model/adv_newtitle/adv_newtitle_tex.tbl": (
+        32,
+        "726FDA272698A32F45FF68B887627BB1A732C2044F253968D574764311CC90AC",
+    ),
+}
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest().upper()
+
+
+def verify(label: str, data: bytes, size: int, digest: str) -> None:
+    actual = sha256(data)
+    if len(data) != size or actual != digest:
+        raise ValueError(
+            f"{label} verification failed: size={len(data)} sha256={actual}; "
+            f"expected size={size} sha256={digest}"
+        )
+
+
+def verify_base(base_drivea: Path) -> None:
+    hostfs = base_drivea / "HOSTFS"
+    if not hostfs.is_dir():
+        raise FileNotFoundError(f"base HOSTFS is missing: {hostfs}")
+    manifest = base_drivea / "IDAS3_DERIVED_ASSETS_v1022.txt"
+    if not manifest.is_file():
+        raise FileNotFoundError(f"v1022 manifest is missing: {manifest}")
+    lines = manifest.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != "IDAS3 v1022 private derived HOSTFS":
+        raise ValueError("input does not have the expected v1022 manifest header")
+    for logical, (size, digest) in V1022_BUNDLE.items():
+        path = hostfs / Path(logical)
+        if not path.is_file():
+            raise FileNotFoundError(f"v1022 asset is missing: {path}")
+        verify(f"v1022 {logical}", path.read_bytes(), size, digest)
+
+
+def read_assets(tools: Path, bin_path: Path, pic_path: Path) -> dict[str, bytes]:
+    tools = tools.resolve()
+    extractor = tools / "extract_dimm_iso.py"
+    if not extractor.is_file():
+        raise FileNotFoundError(f"private extractor is missing: {extractor}")
+    sys.path.insert(0, str(tools))
+    from extract_dimm_iso import (  # type: ignore[import-not-found]
+        DEFAULT_DIMM_ISO_BASE,
+        DimmIso,
+        EncryptedPayloadReader,
+        find_dimm_iso_base,
+        locate_encrypted_payload,
+    )
+
+    bin_path = bin_path.resolve()
+    pic_path = pic_path.resolve()
+    high_base, _target_name, target, pic_key = locate_encrypted_payload(
+        bin_path, pic_path
+    )
+    outputs: dict[str, bytes] = {}
+    with EncryptedPayloadReader(
+        bin_path, high_base, target["extent"], target["size"], pic_key
+    ) as reader:
+        iso = DimmIso(
+            reader, find_dimm_iso_base(reader, DEFAULT_DIMM_ISO_BASE)
+        )
+        for asset in ASSETS:
+            entry, resolved = iso.resolve(asset.physical)
+            if entry.is_dir:
+                raise IsADirectoryError(str(resolved))
+            if entry.extent != asset.extent:
+                raise ValueError(
+                    f"{asset.physical} extent is 0x{entry.extent:08X}; "
+                    f"expected 0x{asset.extent:08X}"
+                )
+            payload = iso.read_file(entry)
+            verify(asset.physical, payload, asset.size, asset.digest)
+            outputs[asset.logical] = payload
+    return outputs
+
+
+def build(
+    base_drivea: Path,
+    output_drivea: Path | None,
+    tools: Path,
+    bin_path: Path,
+    pic_path: Path,
+) -> None:
+    base_drivea = base_drivea.resolve()
+    verify_base(base_drivea)
+    outputs = read_assets(tools, bin_path, pic_path)
+
+    if output_drivea is None:
+        print("Verified exact course lookup assets from the user-owned dump:")
+        for logical, payload in outputs.items():
+            print(f"  {logical} size={len(payload)} sha256={sha256(payload)}")
+        return
+
+    output_drivea = output_drivea.resolve()
+    if output_drivea == base_drivea:
+        raise ValueError("output driveA must be distinct from the input tree")
+    if output_drivea.exists():
+        raise FileExistsError(f"refusing to replace existing output: {output_drivea}")
+    output_drivea.parent.mkdir(parents=True, exist_ok=True)
+
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{output_drivea.name}.tmp-", dir=output_drivea.parent)
+    )
+    try:
+        shutil.copytree(base_drivea / "HOSTFS", staging / "HOSTFS")
+        for inherited in sorted(base_drivea.glob("IDAS3_DERIVED_ASSETS_v*.txt")):
+            shutil.copy2(inherited, staging / inherited.name)
+        for logical, payload in outputs.items():
+            destination = staging / "HOSTFS" / Path(logical)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(payload)
+
+        manifest = [
+            "IDAS3 v1023 private derived HOSTFS",
+            "Exact course environment/path lookup recovery",
+            "Source data remains in the user's own GDS-0033/PIC pair",
+            f"base={base_drivea}",
+            "",
+        ]
+        for asset in ASSETS:
+            payload = outputs[asset.logical]
+            manifest.append(
+                f"{asset.physical} extent=0x{asset.extent:08X} "
+                f"-> HOSTFS/{asset.logical} size={len(payload)} "
+                f"sha256={sha256(payload)}"
+            )
+        (staging / "IDAS3_DERIVED_ASSETS_v1023.txt").write_text(
+            "\n".join(manifest) + "\n", encoding="utf-8"
+        )
+        os.replace(staging, output_drivea)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    print(f"output driveA: {output_drivea}")
+    for logical, payload in outputs.items():
+        print(f"  {logical} size={len(payload)} sha256={sha256(payload)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build or verify the private v1023 course lookup HOSTFS overlay"
+    )
+    parser.add_argument("--base-drivea", required=True, type=Path)
+    parser.add_argument("--tools", required=True, type=Path)
+    parser.add_argument("--bin", required=True, type=Path)
+    parser.add_argument("--pic", required=True, type=Path)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--output-drivea", type=Path)
+    mode.add_argument("--verify-only", action="store_true")
+    args = parser.parse_args()
+    build(
+        args.base_drivea,
+        None if args.verify_only else args.output_drivea,
+        args.tools,
+        args.bin,
+        args.pic,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/translator/codegen.py
+++ b/translator/codegen.py
@@ -405,6 +405,13 @@ def recompile_function(name, base_addr, raw_bytes, unresolved_ctr=None, resolved
                 out.extend(gen_delay_slot(d_addr, d_mnem, d_args, func_start, func_end))
             addr_key = f"{addr:08x}"
             target_hex = resolved_calls.get(addr_key)
+            # This call site joins two guest branches that install different
+            # callbacks. A flat reference map can record only one target and
+            # would silently replace the other callback. Keep the runtime R1
+            # selection; host_indirect_call still dispatches only to static
+            # AOT-translated functions.
+            if addr_key == "0c1f10c8":
+                target_hex = None
             emp_target = empirical_calls.get(addr_key)
             HOST_SHIMS = {
                 "0C04C860": "shim_file_exists",


### PR DESCRIPTION
## What changed

- updates the public checkpoint from v1335 to the current v2018 WIP state
- replaces the obsolete submitted-stream blocker with the current priorities: first controllable race, full-sequence graphics validation, timing/audio/input, and sustained 60 FPS
- documents the recovered course environment lookup failure and its exact physical-to-logical ISO mappings
- adds a source-safe, hash-checked utility that verifies or prepares the two files from user-owned GDS-0033/PIC inputs
- preserves runtime callback selection at the SH-4 call site where a flat reference target would select the wrong installer

## Why

The previous public status still described the stage-112 ELAN lifecycle stall, but the private static-AOT integration now advances sustained native Naomi 2 scenes. The latest visible corruption came from two missing ISO9660-truncated course files: their absent logical names left a guest lookup pointer null and caused unrelated low-memory bytes to be interpreted as environment selectors.

## User and developer impact

The repository now accurately shows what has been demonstrated, what remains unfinished, and how legally owned inputs can be checked without redistributing game data. It still does not claim to be a playable build or include any game program, BIOS, PIC, extracted assets, generated game translation, private memory state, reference capture, or rendered game frame.

## Validation

- `python -m unittest discover -s tests -v` — 5/5 passed
- `cmake -S . -B build` — passed
- `cmake --build build --config Release` — passed
- `ctest --test-dir build -C Release --output-on-failure` — 1/1 passed
- `python -m py_compile tools/prepare_v1023_course_lookup_hostfs.py` — passed
- preparation utility `--verify-only` against the user's private GDS-0033/PIC pair — both exact files passed size and SHA-256 verification
- `git diff --check` — passed
