### PR TITLE
Publish v2396 custom-BGM synchronization checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2374-wip — 2026-08-30
+
+- Profiled a reproducible cold `k_ez` race-start slowdown and ruled out Vulkan, ELAN average cost, AICA, and repeated presentation endpoints.
+- Traced the dominant guest-side startup cost to the game's canonical byte-wise object clear.
+- Added a private exact bulk-main-RAM path that retains one guest memory cycle per byte and final SH-4 registers/flags, while leaving device, VRAM, ELAN, host-aperture, boundary-crossing, and zero-length cases on the original translated path.
+- Improved the identical resolved-input/card route from 100.0 minimum / 116.609 average generated FPS on v2373 to 120.0 minimum / 120.0 average on v2374 across 23 complete two-second race intervals.
+- Confirmed a zero repeat-counter delta during moving gameplay, zero faults, and unchanged course/transition timing.
+- Added helper-level and exact-linked-function regression coverage, revalidated the card-eject BRAF classifier, and passed the native audio/music, presenter, ELAN/JVS/card, AICA, and Vulkan suites.
+- Reconfirmed the private build is BIOS-free through a standalone audit reporting zero firmware callbacks, objects, input contracts, or cached firmware translations.
+- Kept broader course validation, exhaustive whole-game coverage, physical hardware acceptance, and unlimited presentation explicit as open work.
+
 ## v2217-wip — 2026-08-27
 
 - Extended the independent fixed presentation cadence to the native 60 Hz target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2396-wip — 2026-08-30
+
+- Removed the optional held-View host OST picker and kept song selection on a quick Change View press in the authentic opponent selector.
+- Added filename-based custom BGM titles only for slots with valid user replacements; clearing a slot leaves the original game title and music.
+- Unified physical, controller, and deterministic replay View input at the final logical JVS boundary.
+- Narrowed song-selection context from early card/mode screens to the real course-specific rival-face selector.
+- Synchronized the displayed 0/1–13 choice with the actual race stream, custom decoder, and AICA mixer; one bounded live route proved all layers agree.
+- Rebuilt the translated `DIAG_0C0E6280.obj` owner that supplies the active inline asset-loading shim and added an automatic freshness gate so stale COMDAT behavior cannot silently return.
+- Reconfirmed the product is BIOS-free and contains zero firmware callbacks, firmware AOT objects, firmware input contracts, or cached firmware translations.
+- Kept the demo executable, game data, translated guest bodies, cards, private logs, and user music out of the public repository.
+
 ## v2374-wip — 2026-08-30
 
 - Profiled a reproducible cold `k_ez` race-start slowdown and ruled out Vulkan, ELAN average cost, AICA, and repeated presentation endpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2216-wip — 2026-08-26
+
+- Advanced the private NAOMI 2 static-AOT integration through targeted menu, loading, live-race, result, and disposable-card save/reload paths without an interpreter or JIT fallback.
+- Corrected tested HUD projection, mirror placement, car visibility/texture mapping, modifier-volume behavior, audio ring lifecycle, JVS input, and digital-shifter behavior.
+- Added a persistent renderer worker pool and batched Vulkan texture-upload barriers.
+- Identified seven race-entry Vulkan pipeline variants through timing probes and prewarmed them at initialization, reducing the two heaviest measured entry frames from 20.97/19.01 ms to 11.36/5.69 ms with zero in-frame pipeline creation.
+- Validated sustained 3840×2160 presentation at 59.9–60.2 FPS after live motion begins and 1920×1080 presentation interpolation at 119.8–120.1 FPS while preserving authentic guest timing.
+- Verified sustained AICA output/race-stream selection, no-card operation, and disposable-card persistence while keeping automated QA muted and isolated from real card data.
+- Kept remaining limitations explicit: whole-game coverage, two synchronous transition-load gaps, physical wheel/audio acceptance, clean-machine packaging, and uncapped presentation remain open.
+- Removed Dreamcast from the roadmap; this remains a NAOMI 2 recompilation project.
+
 ## v2018-wip — 2026-08-18
 
 - Advanced the private static-AOT runtime beyond the earlier submitted-stream lifecycle blocker into sustained native Naomi 2 scene presentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v2217-wip — 2026-08-27
+
+- Extended the independent fixed presentation cadence to the native 60 Hz target.
+- Traced the earlier 29.3/51.2 FPS race-entry samples to the 60 Hz presenter waiting for a new guest scene during synchronous course/music loads, rather than slow raster or Vulkan work.
+- Retained the last completed image during those guest pauses without advancing game functions, timers, input, audio sequencing, or physics.
+- Validated 43 takeover/race samples at 3840×2160 between 59.8 and 60.1 FPS while normal JVS/physics input drove 668.687 m.
+- Revalidated 1920×1080 at 120 FPS between 119.8 and 120.1 during operation; recorded a diagnostic-only shutdown-dump outlier separately.
+- Kept whole-game coverage, underlying load latency, hardware acceptance, packaging, and uncapped presentation as explicit open work.
+
 ## v2216-wip — 2026-08-26
 
 - Advanced the private NAOMI 2 static-AOT integration through targeted menu, loading, live-race, result, and disposable-card save/reload paths without an interpreter or JIT fallback.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,18 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
-## What works today (2026-08-18)
+## What works today (2026-08-26)
 
 - A Python SH-4 decoder/code generator covers the instruction families exercised by the current static-AOT path, including FPSCR-aware floating-point register width and bank handling.
-- Native C++ execution cold-boots into sustained attract-mode rendering with direct translated-function dispatch and no interpreter or JIT fallback.
+- Native C++ execution cold-boots, advances through targeted menu and loading paths, enters live races, drives through normal JVS/physics input, and reaches tested result/save flows with direct translated-function dispatch and no interpreter or JIT fallback.
 - The submitted ELAN stream, CH2 DMA, render-complete interrupts, retained scenes, and native presentation path now advance continuously instead of stalling at the earlier frame-lifecycle frontier.
 - The Naomi 2 renderer handles the observed opaque, translucent, modifier-volume, punch-through, fog, blend, texture, and user-tile-clip cases used by the current scenes.
 - A missing course environment/path lookup was traced to two ISO9660-truncated files. A source-safe tool now restores their logical names from a user's own dump and verifies exact hashes.
-- A corrected native sequence renders a single coherent textured Trueno with stable camera motion at a 60 FPS presentation target; the earlier alternating rainbow/static environment maps are gone.
+- The renderer now preserves the tested HUD, mirror placement, projection, car geometry, texture mapping, and translucent/modifier-volume behavior through targeted menu and race scenes.
+- A persistent renderer worker pool and Vulkan pipeline prewarming remove the measured CPU thread-creation jitter and cold race-entry pipeline compilation stalls.
+- The private integration build sustains 59.9–60.2 FPS after live race motion begins at 3840×2160, and 119.8–120.1 FPS at 1920×1080 using presentation interpolation while preserving authentic guest timing and physics.
+- AICA/ARM7 processing produces sustained non-silent output and selects the tested race music stream; automated QA runs use a deliberate null audio sink.
+- Keyboard/JVS controls, digital shifter routes, no-card operation, and a disposable-card insert/load/save/reload path pass focused tests.
 - Cross-machine N70 validation reproduced an identical rendered-frame SHA-256: `34D6B91C0550A5CC2A60D4B1F8930812908CEA6DCD6C354749A0881BE426D9E2`.
 - Private integration tests cover ELAN command/VRAM classification, JVS identity and EEPROM behavior, Maple VBlank/reset behavior, Naomi system-ROM write protection, Flycast-derived AICA SGC/mailbox behavior, and PVR twiddled texture layout.
 
@@ -25,14 +29,18 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 
 ## What does not work yet
 
-- The result is not a start-to-finish playable build.
-- A complete controllable race has not yet been reached and validated end to end.
-- The entire intro/menu/course-loading sequence still needs frame-by-frame correctness checks; later texture, depth, transparency, shadow, fog, overlay, and camera issues may remain.
-- The current diagnostic renderer does not consistently sustain 60 unique rendered frames per second and still needs profiling and optimization.
-- Complete cabinet controls, synchronized game audio, whole-game static-AOT coverage, long-run determinism, and presentation polish remain incomplete.
+- This is not a finished or publicly playable game package, and it must not be treated as whole-game completion.
+- Every course, car, weather condition, opponent, Legend route, Time Trial, Bunta Challenge, result branch, and card-error branch has not yet been exhaustively validated.
+- Two measured race-entry intervals still contain synchronous guest asset/music loading gaps before car motion begins; steady race presentation is not affected by those transition gaps.
+- Physical wheel force feedback and audible end-user audio acceptance still need hardware validation even though the software paths and automated checks advance.
+- Unlimited presentation rate independent of gameplay is not complete. The validated high-rate target is currently 120 FPS with original guest timing.
+- Long-run determinism, clean-machine user packaging, crash diagnostics, and remaining presentation polish are still open.
 - The public repository deliberately omits private generated game code, captures, and all legally restricted inputs, so it is not a standalone game build.
 
-See [STATUS.md](STATUS.md) for the evidence ledger and [ROADMAP.md](ROADMAP.md) for ordered acceptance criteria.
+See [STATUS.md](STATUS.md) for the evidence ledger,
+[the current source-safe checkpoint](docs/CURRENT_CHECKPOINT_2026-08-26.md)
+for the latest measured results, and [ROADMAP.md](ROADMAP.md) for ordered
+acceptance criteria.
 
 ## Repository contents
 
@@ -43,8 +51,8 @@ See [STATUS.md](STATUS.md) for the evidence ledger and [ROADMAP.md](ROADMAP.md) 
 
 The renderer snapshot is included to show the real integration work, while the
 complete private runtime and generated translation units remain intentionally
-absent. The new preparation utility also contains no game data: it operates
-only on user-supplied legally owned inputs.
+absent. The preparation utility also contains no game data: it operates only
+on user-supplied legally owned inputs.
 
 ## Run the public checks
 
@@ -66,6 +74,7 @@ No proprietary input is needed for either check.
 
 ## Project boundary
 
-this is a native static-AOT port
+The private integration build is a native static-AOT recompilation of the
+NAOMI 2 game. A Dreamcast port is explicitly outside the project scope.
 
 This independent research project is not affiliated with or endorsed by Sega, Kodansha, Shuichi Shigeno, or the original developers and publishers. All referenced names and trademarks belong to their respective owners.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
-## What works today (2026-08-27)
+## What works today (2026-08-30)
 
 - A Python SH-4 decoder/code generator covers the instruction families exercised by the current static-AOT path, including FPSCR-aware floating-point register width and bank handling.
 - Native C++ execution cold-boots, advances through targeted menu and loading paths, enters live races, drives through normal JVS/physics input, and reaches tested result/save flows with direct translated-function dispatch and no interpreter or JIT fallback.
@@ -19,9 +19,11 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 - A missing course environment/path lookup was traced to two ISO9660-truncated files. A source-safe tool now restores their logical names from a user's own dump and verifies exact hashes.
 - The renderer now preserves the tested HUD, mirror placement, projection, car geometry, texture mapping, and translucent/modifier-volume behavior through targeted menu and race scenes.
 - A persistent renderer worker pool and Vulkan pipeline prewarming remove the measured CPU thread-creation jitter and cold race-entry pipeline compilation stalls.
-- The private integration build sustains a fixed 59.8–60.1 FPS presentation cadence through tested race loading/takeover and live motion at 3840×2160. During synchronous guest loads it retains the last completed image without advancing gameplay. It also sustains 119.8–120.1 FPS at 1920×1080 using presentation interpolation while preserving authentic guest timing and physics.
+- The private integration build keeps game logic, physics, timers, input, and audio on the authentic 60 Hz guest cadence while presenting distinct interpolated motion at 120 Hz. On the fixed `k_ez` regression route, v2374 produced exactly 120 new motion samples in all 23 complete two-second race intervals, with no repeated moving-race endpoints and no faults.
+- A guest-side cold-start hotspot was traced to the game's canonical byte-wise object clear. The private integration now bulk-clears only proven ordinary-main-RAM ranges while preserving one guest memory cycle per byte, final SH-4 registers/flags, and the original fallback for every other mapping.
 - AICA/ARM7 processing produces sustained non-silent output and selects the tested race music stream; automated QA runs use a deliberate null audio sink.
 - Keyboard/JVS controls, digital shifter routes, no-card operation, and a disposable-card insert/load/save/reload path pass focused tests.
+- The private launcher performs BIOS-free setup from user-owned inputs, reports missing/corrupt inputs with normal Windows errors, and requires no separate Python installation. Card files and custom race-music mappings are managed in user-visible folders.
 - Cross-machine N70 validation reproduced an identical rendered-frame SHA-256: `34D6B91C0550A5CC2A60D4B1F8930812908CEA6DCD6C354749A0881BE426D9E2`.
 - Private integration tests cover ELAN command/VRAM classification, JVS identity and EEPROM behavior, Maple VBlank/reset behavior, Naomi system-ROM write protection, Flycast-derived AICA SGC/mailbox behavior, and PVR twiddled texture layout.
 
@@ -31,14 +33,14 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 
 - This is not a finished or publicly playable game package, and it must not be treated as whole-game completion.
 - Every course, car, weather condition, opponent, Legend route, Time Trial, Bunta Challenge, result branch, and card-error branch has not yet been exhaustively validated.
-- Synchronous guest asset/music loading still pauses creation of new game scenes before car motion begins, but the fixed presenter now maintains 60 Hz with the last completed image during that transition.
+- Some synchronous guest asset/music loading still pauses creation of new game scenes before car motion begins. The fixed presenter maintains cadence during static transitions, and the proven `k_ez` cold-race hotspot is removed, but other courses still require the same validation.
 - Physical wheel force feedback and audible end-user audio acceptance still need hardware validation even though the software paths and automated checks advance.
 - Unlimited presentation rate independent of gameplay is not complete. The validated high-rate target is currently 120 FPS with original guest timing.
 - Long-run determinism, clean-machine user packaging, crash diagnostics, and remaining presentation polish are still open.
 - The public repository deliberately omits private generated game code, captures, and all legally restricted inputs, so it is not a standalone game build.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
-[the current source-safe checkpoint](docs/CURRENT_CHECKPOINT_2026-08-27.md)
+[the current source-safe checkpoint](docs/CURRENT_CHECKPOINT_2026-08-30.md)
 for the latest measured results, and [ROADMAP.md](ROADMAP.md) for ordered
 acceptance criteria.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
-## What works today (2026-08-26)
+## What works today (2026-08-27)
 
 - A Python SH-4 decoder/code generator covers the instruction families exercised by the current static-AOT path, including FPSCR-aware floating-point register width and bank handling.
 - Native C++ execution cold-boots, advances through targeted menu and loading paths, enters live races, drives through normal JVS/physics input, and reaches tested result/save flows with direct translated-function dispatch and no interpreter or JIT fallback.
@@ -19,7 +19,7 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 - A missing course environment/path lookup was traced to two ISO9660-truncated files. A source-safe tool now restores their logical names from a user's own dump and verifies exact hashes.
 - The renderer now preserves the tested HUD, mirror placement, projection, car geometry, texture mapping, and translucent/modifier-volume behavior through targeted menu and race scenes.
 - A persistent renderer worker pool and Vulkan pipeline prewarming remove the measured CPU thread-creation jitter and cold race-entry pipeline compilation stalls.
-- The private integration build sustains 59.9–60.2 FPS after live race motion begins at 3840×2160, and 119.8–120.1 FPS at 1920×1080 using presentation interpolation while preserving authentic guest timing and physics.
+- The private integration build sustains a fixed 59.8–60.1 FPS presentation cadence through tested race loading/takeover and live motion at 3840×2160. During synchronous guest loads it retains the last completed image without advancing gameplay. It also sustains 119.8–120.1 FPS at 1920×1080 using presentation interpolation while preserving authentic guest timing and physics.
 - AICA/ARM7 processing produces sustained non-silent output and selects the tested race music stream; automated QA runs use a deliberate null audio sink.
 - Keyboard/JVS controls, digital shifter routes, no-card operation, and a disposable-card insert/load/save/reload path pass focused tests.
 - Cross-machine N70 validation reproduced an identical rendered-frame SHA-256: `34D6B91C0550A5CC2A60D4B1F8930812908CEA6DCD6C354749A0881BE426D9E2`.
@@ -31,14 +31,14 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 
 - This is not a finished or publicly playable game package, and it must not be treated as whole-game completion.
 - Every course, car, weather condition, opponent, Legend route, Time Trial, Bunta Challenge, result branch, and card-error branch has not yet been exhaustively validated.
-- Two measured race-entry intervals still contain synchronous guest asset/music loading gaps before car motion begins; steady race presentation is not affected by those transition gaps.
+- Synchronous guest asset/music loading still pauses creation of new game scenes before car motion begins, but the fixed presenter now maintains 60 Hz with the last completed image during that transition.
 - Physical wheel force feedback and audible end-user audio acceptance still need hardware validation even though the software paths and automated checks advance.
 - Unlimited presentation rate independent of gameplay is not complete. The validated high-rate target is currently 120 FPS with original guest timing.
 - Long-run determinism, clean-machine user packaging, crash diagnostics, and remaining presentation polish are still open.
 - The public repository deliberately omits private generated game code, captures, and all legally restricted inputs, so it is not a standalone game build.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
-[the current source-safe checkpoint](docs/CURRENT_CHECKPOINT_2026-08-26.md)
+[the current source-safe checkpoint](docs/CURRENT_CHECKPOINT_2026-08-27.md)
 for the latest measured results, and [ROADMAP.md](ROADMAP.md) for ordered
 acceptance criteria.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 - Keyboard/JVS controls, digital shifter routes, no-card operation, and a disposable-card insert/load/save/reload path pass focused tests.
 - The private launcher performs BIOS-free setup from user-owned inputs, reports missing/corrupt inputs with normal Windows errors, and requires no separate Python installation. Card files and custom race-music mappings are managed in user-visible folders.
 - The F1 settings UI now covers video, controls/key binding, force-feedback strength, HUD layout, card selection/insertion, and 13 custom race-music slots. Quick View Change on the authentic opponent selector cycles entry 0/no music and songs 1–13; a replacement displays its sanitized filename and follows the game’s real stream start/stop commands.
-- Whole-route QA has loaded all 48 defined route/branch targets and produced real movement for all 32 rival profiles. All 16 Time Trial layouts have natural result evidence; natural rival-result coverage is 25/32.
+- Whole-route QA has loaded all 48 defined route/branch targets and produced real movement for all 32 rival profiles. All 16 Time Trial layouts and all 32 rival profiles now have natural, game-owned result evidence.
 - v2391 removed an independent preview limiter that could discard valid authentic 60 Hz scenes before 120 Hz interpolation. The measured four-course priority matrix holds 119.8–120.0 FPS minimum presentation with zero repeated endpoints during accepted moving intervals.
 - v2396 fixed an inline-COMDAT linkage trap in the host asset loader, synchronized opponent-menu custom titles with the selected race stream, and added a build gate that rejects stale translated owners. The standalone audit again reports zero firmware callbacks, firmware objects, or firmware input contracts.
 - Cross-machine N70 validation reproduced an identical rendered-frame SHA-256: `34D6B91C0550A5CC2A60D4B1F8930812908CEA6DCD6C354749A0881BE426D9E2`.
@@ -36,7 +36,7 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 ## What does not work yet
 
 - This is not a finished or publicly playable game package, and it must not be treated as whole-game completion.
-- Every visual combination, weather condition, long campaign permutation, and card-error branch has not yet been exhaustively validated. Seven rival profiles still lack a natural-result proof even though all 32 load and move.
+- Every visual combination, weather condition, long campaign permutation, and card-error branch has not yet been exhaustively validated. The 32/32 natural-rival milestone closes opponent result coverage, not those broader combinations.
 - Some synchronous guest asset/music loading still pauses creation of new game scenes before car motion begins. The fixed presenter maintains cadence during static transitions, and the proven `k_ez` cold-race hotspot is removed, but other courses still require the same validation.
 - Physical wheel force feedback and audible end-user audio acceptance still need hardware validation even though the software paths and automated checks advance.
 - Unlimited presentation rate independent of gameplay is not complete. The validated high-rate target is currently 120 FPS with original guest timing.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 - AICA/ARM7 processing produces sustained non-silent output and selects the tested race music stream; automated QA runs use a deliberate null audio sink.
 - Keyboard/JVS controls, digital shifter routes, no-card operation, and a disposable-card insert/load/save/reload path pass focused tests.
 - The private launcher performs BIOS-free setup from user-owned inputs, reports missing/corrupt inputs with normal Windows errors, and requires no separate Python installation. Card files and custom race-music mappings are managed in user-visible folders.
+- The F1 settings UI now covers video, controls/key binding, force-feedback strength, HUD layout, card selection/insertion, and 13 custom race-music slots. Quick View Change on the authentic opponent selector cycles entry 0/no music and songs 1–13; a replacement displays its sanitized filename and follows the game’s real stream start/stop commands.
+- Whole-route QA has loaded all 48 defined route/branch targets and produced real movement for all 32 rival profiles. All 16 Time Trial layouts have natural result evidence; natural rival-result coverage is 25/32.
+- v2391 removed an independent preview limiter that could discard valid authentic 60 Hz scenes before 120 Hz interpolation. The measured four-course priority matrix holds 119.8–120.0 FPS minimum presentation with zero repeated endpoints during accepted moving intervals.
+- v2396 fixed an inline-COMDAT linkage trap in the host asset loader, synchronized opponent-menu custom titles with the selected race stream, and added a build gate that rejects stale translated owners. The standalone audit again reports zero firmware callbacks, firmware objects, or firmware input contracts.
 - Cross-machine N70 validation reproduced an identical rendered-frame SHA-256: `34D6B91C0550A5CC2A60D4B1F8930812908CEA6DCD6C354749A0881BE426D9E2`.
 - Private integration tests cover ELAN command/VRAM classification, JVS identity and EEPROM behavior, Maple VBlank/reset behavior, Naomi system-ROM write protection, Flycast-derived AICA SGC/mailbox behavior, and PVR twiddled texture layout.
 
@@ -32,15 +36,15 @@ An experimental static ahead-of-time recompilation project for the NAOMI 2 relea
 ## What does not work yet
 
 - This is not a finished or publicly playable game package, and it must not be treated as whole-game completion.
-- Every course, car, weather condition, opponent, Legend route, Time Trial, Bunta Challenge, result branch, and card-error branch has not yet been exhaustively validated.
+- Every visual combination, weather condition, long campaign permutation, and card-error branch has not yet been exhaustively validated. Seven rival profiles still lack a natural-result proof even though all 32 load and move.
 - Some synchronous guest asset/music loading still pauses creation of new game scenes before car motion begins. The fixed presenter maintains cadence during static transitions, and the proven `k_ez` cold-race hotspot is removed, but other courses still require the same validation.
 - Physical wheel force feedback and audible end-user audio acceptance still need hardware validation even though the software paths and automated checks advance.
 - Unlimited presentation rate independent of gameplay is not complete. The validated high-rate target is currently 120 FPS with original guest timing.
-- Long-run determinism, clean-machine user packaging, crash diagnostics, and remaining presentation polish are still open.
+- Long-run determinism, broader clean-machine packaging, crash diagnostics, and remaining presentation polish are still open.
 - The public repository deliberately omits private generated game code, captures, and all legally restricted inputs, so it is not a standalone game build.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
-[the current source-safe checkpoint](docs/CURRENT_CHECKPOINT_2026-08-30.md)
+[the current source-safe checkpoint](docs/CURRENT_CHECKPOINT_V2396_2026-08-30.md)
 for the latest measured results, and [ROADMAP.md](ROADMAP.md) for ordered
 acceptance criteria.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,13 +47,17 @@ target even though presentation cadence is now stable.
 - The measured cold `k_ez` startup hotspot was removed with an exact ordinary-main-RAM object-clear path.
 - All 23 complete two-second race intervals produced exactly 120 new presentation frames; the moving-race repeat counter stayed flat and the log contained zero faults.
 
-Checkpoint result: passed for the fixed `k_ez` regression route. The same gate
-must still be protected across other courses before 120 FPS is considered
-whole-game validated.
+Checkpoint result: passed for the fixed `k_ez` regression route and the
+four-course priority matrix (`s_uh`, `s_vh`, `s_nm`, and `k_df3`). Exhaustive
+content protection is still required before 120 FPS is called whole-game
+validated.
 
 ## P2 — Whole-game coverage and regression testing
 
 - Cover every car, course, mode, results/continue flow, save/configuration path, and long run.
+- Finish the seven remaining natural rival-result proofs; current evidence is
+  48/48 target loads, 32/32 rival movement, 16/16 natural Time Trial results,
+  and 25/32 natural rival results.
 - Eliminate unresolved indirect targets and compatibility-only diagnostics.
 - Add deterministic public tests for every source-safe subsystem.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,17 @@ Checkpoint result: 59.8–60.1 FPS across 43 samples from tested 4K race takeove
 onward. Reducing the underlying guest loading latency remains a transition-level
 target even though presentation cadence is now stable.
 
+## Validated checkpoint — Distinct 120 Hz on the measured cold route
+
+- Guest logic, physics, timers, input, and audio remain at the authentic 60 Hz cadence.
+- Presentation interpolation generates intermediate motion samples without advancing the game twice.
+- The measured cold `k_ez` startup hotspot was removed with an exact ordinary-main-RAM object-clear path.
+- All 23 complete two-second race intervals produced exactly 120 new presentation frames; the moving-race repeat counter stayed flat and the log contained zero faults.
+
+Checkpoint result: passed for the fixed `k_ez` regression route. The same gate
+must still be protected across other courses before 120 FPS is considered
+whole-game validated.
+
 ## P2 — Whole-game coverage and regression testing
 
 - Cover every car, course, mode, results/continue flow, save/configuration path, and long run.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,15 +2,13 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## P0 — Reach and control the first complete race
+## Validated checkpoint — Targeted complete race path
 
-- Complete the intro, menu, course-loading, race, results, and return transitions.
-- Remove any remaining static-AOT target gaps, stalls, or device-handshake blockers on that path.
-- Prove steering, accelerator, brake, gears, buttons, coin/service, and race timers together.
+- Targeted intro, menu, course-loading, live-race, result, and disposable-card save transitions now advance through the static native path.
+- Normal JVS/physics input drives the player car; keyboard, analog, and digital-shifter routes pass focused tests.
+- Remaining work is to repeat these gates across every mode, course, opponent, outcome, and error branch.
 
-Acceptance: a user can cold boot from legally owned inputs, enter a race, drive,
-finish or exit, and return through the native static path without an
-interpreter/JIT fallback.
+Checkpoint result: passed on targeted routes, not yet claimed across the whole game.
 
 ## P0 — Validate the complete rendered sequence
 
@@ -31,14 +29,14 @@ without duplicated objects, fabricated textures, or manual replacement frames.
 Acceptance: gameplay behaves consistently at different host presentation targets
 with synchronized sound and complete cabinet controls.
 
-## P1 — Sustain the 60 FPS presentation target
+## Validated checkpoint — Sustain the 60 FPS presentation target
 
-- Profile rasterization, texture decode/cache use, scene retention, and memory copies.
-- Optimize only after correctness gates protect the output.
-- Preserve deterministic results across worker counts and machines.
+- Persistent renderer workers remove per-frame thread churn.
+- Vulkan pipeline prewarming removes measured cold race-entry compilation from active frames.
+- Clean acceptance runs sustain 4K/60 during race motion and 1080p/120 presentation interpolation while preserving guest timing.
 
-Acceptance: release builds sustain 60 unique presented frames per second at the
-baseline resolution on the target PC class without changing guest timing.
+Checkpoint result: 59.9–60.2 FPS at 3840×2160 after motion begins. Two
+synchronous guest loading gaps before motion remain a transition-level target.
 
 ## P2 — Whole-game coverage and regression testing
 
@@ -46,7 +44,9 @@ baseline resolution on the target PC class without changing guest timing.
 - Eliminate unresolved indirect targets and compatibility-only diagnostics.
 - Add deterministic public tests for every source-safe subsystem.
 
-Acceptance: cold boot through a complete race and return flow, entirely through the native static path.
+Acceptance: every supported mode, course, car, opponent, outcome, and persistence
+branch completes its defined regression path entirely through the native static
+runtime, with no unresolved translated target.
 
 ## P2 — Productization and release packaging
 
@@ -55,3 +55,14 @@ Acceptance: cold boot through a complete race and return flow, entirely through 
 - Performance profiling and native hot-path optimization after correctness gates pass.
 
 Acceptance: clean-machine documentation and packaging that never redistributes third-party game content.
+
+## P3 — Enhanced presentation after correctness and coverage
+
+- Finish configurable higher-resolution, widescreen, filtering, anti-aliasing, HUD, and display options through the F1 menu.
+- Validate 120 FPS across content while keeping game logic, physics, timers, and audio on authentic guest timing.
+- Pursue unlimited presentation only after the 120 FPS compatibility gate is protected by regressions.
+
+Acceptance: enhanced modes never change gameplay results or replace guest assets,
+and every option has a safe native default.
+
+Dreamcast is not a roadmap target. This project remains a NAOMI 2 static-AOT recompilation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,9 +34,11 @@ with synchronized sound and complete cabinet controls.
 - Persistent renderer workers remove per-frame thread churn.
 - Vulkan pipeline prewarming removes measured cold race-entry compilation from active frames.
 - Clean acceptance runs sustain 4K/60 during race motion and 1080p/120 presentation interpolation while preserving guest timing.
+- Fixed 60 Hz presentation retains the last completed image during synchronous guest loading, so output cadence no longer collapses while gameplay is correctly paused.
 
-Checkpoint result: 59.9–60.2 FPS at 3840×2160 after motion begins. Two
-synchronous guest loading gaps before motion remain a transition-level target.
+Checkpoint result: 59.8–60.1 FPS across 43 samples from tested 4K race takeover
+onward. Reducing the underlying guest loading latency remains a transition-level
+target even though presentation cadence is now stable.
 
 ## P2 — Whole-game coverage and regression testing
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,25 +1,32 @@
 # Status and evidence ledger
 
-Status date: 2026-08-18
-Public checkpoint: v2018 WIP
+Status date: 2026-08-26
+Private integration checkpoint: v2216 WIP
+Public checkpoint: source-safe progress report (non-playable)
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
 
 | Area | Demonstrated | Current limitation |
 |---|---|---|
 | Static SH-4 translation | Broad instruction decoding/code generation; direct translated calls; FPSCR-aware FPU regression tests | Whole-program coverage and every indirect target are not complete |
-| Native boot/runtime | Static translated execution cold-boots and advances sustained native attract-mode scenes | A complete menu-to-race-to-results flow is not yet validated |
+| Native boot/runtime | Static translated execution cold-boots and advances tested menu, loading, live-race, result, and save paths | Whole-game route and error-branch coverage is not complete |
 | Deterministic replay | N70 accepted 70/70 with `unimplemented=0`, `FPSCR=0`, no fault/watchdog, and cross-machine identical frame hash | Uses private user-owned replay/input state that cannot be published |
-| ELAN 3D path | Submitted links, CH2 DMA, completion interrupts, persistent state, materials, instances, lighting, textures, culling, depth, and retained presentation scenes advance continuously | Whole-intro and gameplay correctness still need systematic comparison |
-| PVR rendering | Native handling exists for observed opaque/translucent lists, fog, modifier volumes, punch alpha, blend modes, texture layouts, autosort, and tile clipping | Remaining overlays and rejected/projected geometry need scene-by-scene validation |
+| ELAN 3D path | Submitted links, CH2 DMA, completion interrupts, persistent state, materials, instances, lighting, textures, culling, depth, and retained presentation scenes advance continuously through tested races | Untested cars, courses, weather, and scene combinations still need systematic comparison |
+| PVR rendering | Native handling exists for observed opaque/translucent lists, fog, modifier volumes, punch alpha, blend modes, texture layouts, autosort, tile clipping, tested HUD placement, and mirrors | Remaining combinations and presentation edge cases need scene-by-scene validation |
 | Course environment maps | Missing logical lookup paths were recovered from two exact user-owned ISO files; rainbow/static maps are corrected | Other courses and weather conditions are not yet audited |
-| JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, and keyboard-facing seams pass focused tests | Steering, pedals, gears, buttons, coin/service, and full race control remain to be proven together |
-| Audio | Flycast-derived AICA SGC and mailbox protocol tests pass; the exact driver can be loaded from the private HOSTFS | Complete music, engine, voice, effects, looping, and synchronization remain incomplete |
-| Performance | A coherent sequence survives a 60 FPS presentation target | The diagnostic renderer does not yet sustain 60 unique frames per second |
+| JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, and digital shifter routes pass focused tests | Physical wheel, force-feedback strength, and full cabinet hardware validation remain open |
+| Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples and selects tested race music | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
+| Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload on a tested Legend flow | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
+| Performance | Sustained race motion measures 59.9–60.2 FPS at 3840×2160 and 119.8–120.1 FPS at 1920×1080 without changing guest timing | Two pre-motion transition intervals still include synchronous guest asset/music loads; uncapped presentation is not complete |
 | Distribution | Sanitized source/evidence package and user-owned-input preparation tool | No executable game package; private inputs and generated game code remain excluded |
 
 ## Strongest accepted evidence
 
+- v2216 Windows x64 checkpoint SHA-256: `BE61B4291784A4A98129677FF7B7991BB982346CE1F5550C72547BF6C2FFCC16` (binary intentionally not published).
+- At 3840×2160, genuine JVS/physics-driven race motion advanced 160 m while sampled presentation held 59.9–60.2 FPS.
+- At 1920×1080, all eight sampled race intervals from takeover through 160 m measured 119.8–120.1 FPS using presentation interpolation over authentic guest timing.
+- Vulkan prewarming moved seven observed race-only pipelines to startup. The two heaviest entry frames dropped from 20.97/19.01 ms to 11.36/5.69 ms and created zero pipelines in-frame.
+- The final acceptance runs recorded no fatal, exception, access-violation, unimplemented-target, NSEQ, or Vulkan fault markers.
 - N70 frame SHA-256: `34D6B91C0550A5CC2A60D4B1F8930812908CEA6DCD6C354749A0881BE426D9E2`.
 - Accepted N70 state: 667 batches, 61,498 vertices, 17,490 triangles, 990,196 textured pixels, and 53,996 lit vertices.
 - Full-intro ladder reached N3200 with each recorded run accepted N/N, `unimplemented=0`, `FPSCR=0`, and no recorded memory fault, crash, or watchdog.
@@ -27,17 +34,25 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 
 ## Latest WIP truth
 
-The earlier linked-stream/frame-lifecycle blocker is no longer the active
-frontier. The current native run advances thousands of guest scene frames and
-presents retained Naomi 2 scenes continuously.
+The earlier linked-stream/frame-lifecycle and attract-mode-only blockers are no
+longer the active frontier. The current private native build advances targeted
+menu-to-race and result/save paths, presents retained NAOMI 2 scenes
+continuously, and can drive the player car through normal game inputs.
 
 The latest visual root cause was external asset preparation: two logical course
 lookup names were absent because their ISO9660 physical names are truncated.
 The null table pointer made the guest compositor read unrelated low-memory bytes
 as selectors. Restoring the two exact files from the user's own dump changed
 the invalid selector record to the expected course record and removed the
-alternating rainbow/static environment maps. This does not imply that all
-graphics or gameplay are complete.
+alternating rainbow/static environment maps. Subsequent integration work also
+corrected the tested HUD projection, mirror placement, RX-7 geometry/texture
+failures, and renderer lifecycle defects. This does not imply that all graphics
+or gameplay paths are complete.
+
+The current performance frontier is no longer steady-state 60 FPS. It is broad
+content coverage, two synchronous transition-load gaps, hardware input/audio
+acceptance, release packaging, and eventually uncapped presentation that stays
+independent from guest gameplay timing.
 
 ## Definition of playable
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
 Status date: 2026-08-30
-Private integration checkpoint: v2374 WIP
+Private integration checkpoint: v2396 WIP
 Public checkpoint: source-safe progress report (non-playable)
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -9,18 +9,24 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | Area | Demonstrated | Current limitation |
 |---|---|---|
 | Static SH-4 translation | Broad instruction decoding/code generation; direct translated calls; FPSCR-aware FPU regression tests | Whole-program coverage and every indirect target are not complete |
-| Native boot/runtime | Static translated execution cold-boots and advances tested menu, loading, live-race, result, and save paths | Whole-game route and error-branch coverage is not complete |
+| Native boot/runtime | BIOS-free static translated execution cold-boots and advances tested menu, loading, live-race, result, and save paths; 48/48 route/branch targets load | Remaining long campaign permutations and error branches are not complete |
 | Deterministic replay | N70 accepted 70/70 with `unimplemented=0`, `FPSCR=0`, no fault/watchdog, and cross-machine identical frame hash | Uses private user-owned replay/input state that cannot be published |
 | ELAN 3D path | Submitted links, CH2 DMA, completion interrupts, persistent state, materials, instances, lighting, textures, culling, depth, and retained presentation scenes advance continuously through tested races | Untested cars, courses, weather, and scene combinations still need systematic comparison |
 | PVR rendering | Native handling exists for observed opaque/translucent lists, fog, modifier volumes, punch alpha, blend modes, texture layouts, autosort, tile clipping, tested HUD placement, and mirrors | Remaining combinations and presentation edge cases need scene-by-scene validation |
 | Course environment maps | Missing logical lookup paths were recovered from two exact user-owned ISO files; rainbow/static maps are corrected | Other courses and weather conditions are not yet audited |
-| JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, and digital shifter routes pass focused tests | Physical wheel, force-feedback strength, and full cabinet hardware validation remain open |
-| Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples and selects tested race music | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
+| JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, digital shifter routes, remappable bindings, device selection, and adjustable FFB path pass focused tests | Physical wheel/FFB hardware acceptance and full cabinet validation remain open |
+| Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload on a tested Legend flow | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
-| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation; v2374 held exactly 120 generated motion frames in all 23 complete two-second `k_ez` race intervals with zero moving-race repeats | Other courses still need the same cold-start gate; uncapped presentation is not complete |
+| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation; the four-course priority matrix held 119.8–120.0 FPS minimum with zero accepted moving-race repeats | Exhaustive content coverage and uncapped presentation are not complete |
 | Distribution | Sanitized source/evidence package plus a private BIOS-free, Python-free user-owned-input preparation/launcher flow | No public executable game package; private inputs and generated game code remain excluded |
 
 ## Strongest accepted evidence
+
+- v2396 Windows x64 checkpoint SHA-256: `966F218E54CC2C3A112D174163C85B141DDA25FE96836729D310E8773C555E91` (binary intentionally not published).
+- One BIOS-free 640×480/60 bounded route proved the opponent-menu label, stream override, Media Foundation decode, and AICA replacement activation in a single run while Vulkan held 60.0 Hz and live movement advanced.
+- The build verifier now rejects a translated COMDAT owner that predates the inline host headers it owns. The historical stale build fails with the exact owner name; v2396 passes fresh.
+- Current coverage is 48/48 route/branch loads, 32/32 rival movement, 16/16 natural Time Trial results, and 25/32 natural rival results.
+- The accepted four-course high-refresh matrix measured 119.8–120.0 FPS minimum presentation and no repeated endpoints in accepted moving intervals.
 
 - v2374 Windows x64 checkpoint SHA-256: `81F18BBEA04D42B692BE295630A3F6A6DE8DF6F479ECF4881E38FCAC100FD0C4` (binary intentionally not published).
 - On the identical resolved-input/card `k_ez` route, v2373 measured 100.0 minimum / 116.609 average generated FPS across 22 full race samples. The exact main-RAM object-clear repair raised v2374 to 120.0 minimum / 120.0 average across 23 full samples.
@@ -56,9 +62,9 @@ corrected the tested HUD projection, mirror placement, RX-7 geometry/texture
 failures, and renderer lifecycle defects. This does not imply that all graphics
 or gameplay paths are complete.
 
-The current performance frontier is no longer steady-state 60 FPS or the
-measured `k_ez` cold-race slowdown. It is broad cross-course content coverage,
-reducing remaining synchronous transition latency,
+The current performance frontier is no longer steady-state 60 FPS, the
+measured `k_ez` cold-race slowdown, or the four-course priority matrix. It is
+exhaustive content coverage, reducing remaining synchronous transition latency,
 hardware input/audio acceptance, release packaging, and eventually uncapped
 presentation that stays independent from guest gameplay timing.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
-Status date: 2026-08-27
-Private integration checkpoint: v2217 WIP
+Status date: 2026-08-30
+Private integration checkpoint: v2374 WIP
 Public checkpoint: source-safe progress report (non-playable)
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -17,10 +17,16 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, and digital shifter routes pass focused tests | Physical wheel, force-feedback strength, and full cabinet hardware validation remain open |
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples and selects tested race music | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload on a tested Legend flow | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
-| Performance | Fixed presentation measures 59.8–60.1 FPS through tested 4K race loading/takeover and motion, and 119.8–120.1 FPS at 1080p/120 without changing guest timing | Synchronous loading still delays new guest scenes; uncapped presentation is not complete |
-| Distribution | Sanitized source/evidence package and user-owned-input preparation tool | No executable game package; private inputs and generated game code remain excluded |
+| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation; v2374 held exactly 120 generated motion frames in all 23 complete two-second `k_ez` race intervals with zero moving-race repeats | Other courses still need the same cold-start gate; uncapped presentation is not complete |
+| Distribution | Sanitized source/evidence package plus a private BIOS-free, Python-free user-owned-input preparation/launcher flow | No public executable game package; private inputs and generated game code remain excluded |
 
 ## Strongest accepted evidence
+
+- v2374 Windows x64 checkpoint SHA-256: `81F18BBEA04D42B692BE295630A3F6A6DE8DF6F479ECF4881E38FCAC100FD0C4` (binary intentionally not published).
+- On the identical resolved-input/card `k_ez` route, v2373 measured 100.0 minimum / 116.609 average generated FPS across 22 full race samples. The exact main-RAM object-clear repair raised v2374 to 120.0 minimum / 120.0 average across 23 full samples.
+- The moving-race repeat-counter delta was zero in both runs; v2374's 120 FPS result is distinct interpolated motion, not repeated 60 Hz endpoints.
+- The exact linked memset regression passes zero, one-byte, unaligned 257-byte, and P1-alias 64 KiB cases with preserved registers, T flag, stack, guard bytes, and `length + 2` memory-access cycles.
+- The standalone audit reports zero firmware callbacks, firmware AOT objects, firmware input contracts, or cached firmware translations in v2374.
 
 - v2217 Windows x64 checkpoint SHA-256: `0F225655BF9F32C1FAEE76CF559EABD1D7D5C19A4960BD7A02B512582A4A08E6` (binary intentionally not published).
 - At 3840×2160, 43 samples from takeover onward measured 59.8–60.1 FPS while genuine JVS/physics-driven race motion advanced 668.687 m.
@@ -50,8 +56,9 @@ corrected the tested HUD projection, mirror placement, RX-7 geometry/texture
 failures, and renderer lifecycle defects. This does not imply that all graphics
 or gameplay paths are complete.
 
-The current performance frontier is no longer steady-state 60 FPS. It is broad
-content coverage, reducing the underlying synchronous transition latency,
+The current performance frontier is no longer steady-state 60 FPS or the
+measured `k_ez` cold-race slowdown. It is broad cross-course content coverage,
+reducing remaining synchronous transition latency,
 hardware input/audio acceptance, release packaging, and eventually uncapped
 presentation that stays independent from guest gameplay timing.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
-Status date: 2026-08-26
-Private integration checkpoint: v2216 WIP
+Status date: 2026-08-27
+Private integration checkpoint: v2217 WIP
 Public checkpoint: source-safe progress report (non-playable)
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -17,13 +17,14 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, and digital shifter routes pass focused tests | Physical wheel, force-feedback strength, and full cabinet hardware validation remain open |
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples and selects tested race music | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload on a tested Legend flow | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
-| Performance | Sustained race motion measures 59.9–60.2 FPS at 3840×2160 and 119.8–120.1 FPS at 1920×1080 without changing guest timing | Two pre-motion transition intervals still include synchronous guest asset/music loads; uncapped presentation is not complete |
+| Performance | Fixed presentation measures 59.8–60.1 FPS through tested 4K race loading/takeover and motion, and 119.8–120.1 FPS at 1080p/120 without changing guest timing | Synchronous loading still delays new guest scenes; uncapped presentation is not complete |
 | Distribution | Sanitized source/evidence package and user-owned-input preparation tool | No executable game package; private inputs and generated game code remain excluded |
 
 ## Strongest accepted evidence
 
-- v2216 Windows x64 checkpoint SHA-256: `BE61B4291784A4A98129677FF7B7991BB982346CE1F5550C72547BF6C2FFCC16` (binary intentionally not published).
-- At 3840×2160, genuine JVS/physics-driven race motion advanced 160 m while sampled presentation held 59.9–60.2 FPS.
+- v2217 Windows x64 checkpoint SHA-256: `0F225655BF9F32C1FAEE76CF559EABD1D7D5C19A4960BD7A02B512582A4A08E6` (binary intentionally not published).
+- At 3840×2160, 43 samples from takeover onward measured 59.8–60.1 FPS while genuine JVS/physics-driven race motion advanced 668.687 m.
+- The v2216 29.3/51.2 transition samples were traced to the 60 Hz presenter waiting for new guest scenes during synchronous loads. v2217 retains the last completed image at fixed wall-clock cadence without advancing guest code.
 - At 1920×1080, all eight sampled race intervals from takeover through 160 m measured 119.8–120.1 FPS using presentation interpolation over authentic guest timing.
 - Vulkan prewarming moved seven observed race-only pipelines to startup. The two heaviest entry frames dropped from 20.97/19.01 ms to 11.36/5.69 ms and created zero pipelines in-frame.
 - The final acceptance runs recorded no fatal, exception, access-violation, unimplemented-target, NSEQ, or Vulkan fault markers.
@@ -50,9 +51,9 @@ failures, and renderer lifecycle defects. This does not imply that all graphics
 or gameplay paths are complete.
 
 The current performance frontier is no longer steady-state 60 FPS. It is broad
-content coverage, two synchronous transition-load gaps, hardware input/audio
-acceptance, release packaging, and eventually uncapped presentation that stays
-independent from guest gameplay timing.
+content coverage, reducing the underlying synchronous transition latency,
+hardware input/audio acceptance, release packaging, and eventually uncapped
+presentation that stays independent from guest gameplay timing.
 
 ## Definition of playable
 

--- a/docs/CURRENT_CHECKPOINT_2026-08-26.md
+++ b/docs/CURRENT_CHECKPOINT_2026-08-26.md
@@ -1,0 +1,59 @@
+# Current source-safe checkpoint — 2026-08-26
+
+This document reports the private v2216 integration checkpoint without
+publishing a game binary, generated game translation, ROM/BIOS/PIC/CHD data,
+assets, captures, logs, save/card data, memory snapshots, or private host paths.
+
+## Project boundary
+
+- Target hardware: Sega NAOMI 2.
+- Execution model: native static ahead-of-time SH-4 recompilation.
+- Graphics API: Vulkan.
+- No interpreter, JIT, emulator runtime, fabricated guest state, or replacement game assets.
+- Flycast-derived device knowledge/code may be integrated where licensing permits; Flycast is not the runtime.
+- Dreamcast is outside the project scope.
+
+## Demonstrated in the private integration build
+
+- Cold boot and targeted menu, loading, live-race, result, and save transitions.
+- Player-car movement through normal JVS inputs and game physics rather than teleporting or substituting rendered frames.
+- Corrected tested HUD projection, top mirror placement, RX-7 visibility/texture mapping, retained scenes, modifier volumes, fog, blending, and texture paths.
+- Sustained AICA/ARM7 audio production and tested race-stream selection. Automated QA is deliberately muted through a null sink.
+- Keyboard/analog input, digital-shifter routes, no-card operation, and isolated disposable-card insert/load/save/reload.
+- F1 configuration infrastructure for presentation and input work, with physical wheel/force-feedback acceptance still open.
+
+## Performance checkpoint
+
+Checkpoint executable SHA-256 (binary not distributed):
+
+`BE61B4291784A4A98129677FF7B7991BB982346CE1F5550C72547BF6C2FFCC16`
+
+At 3840×2160, the player car advanced 160 metres through normal JVS/physics
+input. Once live motion began, sampled presentation measured 59.9–60.2 FPS.
+The first two monitoring intervals included synchronous guest course/music
+loading before the car moved and are tracked as transition gaps rather than
+steady renderer overload.
+
+At 1920×1080, eight sampled intervals from takeover through 160 metres measured
+119.8–120.1 FPS. This uses presentation interpolation over authentic guest
+timing; it does not run game logic or physics at double speed.
+
+The renderer now keeps persistent preparation workers instead of creating and
+joining worker threads every frame. Timing probes also identified seven
+race-only Vulkan pipeline variants. Moving those variants to startup reduced
+the two heaviest measured entry frames from 20.97/19.01 ms to 11.36/5.69 ms,
+with zero pipeline creation during those active frames.
+
+The final acceptance runs recorded no fatal, exception, access-violation,
+unimplemented-target, NSEQ, or Vulkan fault markers.
+
+## Remaining work
+
+1. Validate every mode, course, car, opponent, condition, outcome, continue/result path, and card-error branch.
+2. Remove or mask the two synchronous pre-race asset/music transition gaps without changing guest-visible ordering.
+3. Complete hardware acceptance for wheels, force feedback, audio devices, and controller remapping.
+4. Finish clean-machine preparation, crash reporting, settings polish, and legally safe release packaging.
+5. Protect 120 FPS across broader content, then pursue unlimited presentation without changing gameplay, timers, physics, or audio.
+
+This is substantial progress, not a completion claim. The public repository
+remains a source-safe engineering showcase rather than a playable game release.

--- a/docs/CURRENT_CHECKPOINT_2026-08-27.md
+++ b/docs/CURRENT_CHECKPOINT_2026-08-27.md
@@ -1,0 +1,69 @@
+# Current source-safe checkpoint — 2026-08-27
+
+This document reports the private v2217 integration checkpoint without
+publishing a game binary, generated game translation, ROM/BIOS/PIC/CHD data,
+assets, captures, logs, input recordings, save/card data, memory snapshots, or
+private host paths.
+
+## Project boundary
+
+- Target hardware: Sega NAOMI 2.
+- Execution model: native static ahead-of-time SH-4 recompilation.
+- Graphics API: Vulkan.
+- No interpreter, JIT, emulator runtime, fabricated guest state, or replacement game assets.
+- Flycast-derived device knowledge/code may be integrated where licensing permits; Flycast is not the runtime.
+- Dreamcast is outside the project scope.
+
+## v2217 presentation fix
+
+The v2216 renderer was already under the 16.67 ms 60 FPS budget, but its clean
+4K acceptance run contained two 29.3/51.2 FPS samples before car motion. Those
+samples occurred while the guest synchronously loaded course and music data.
+
+The presenter already maintained an independent wall-clock cadence above 60
+Hz by retaining the last completed scene when the guest had not submitted a
+new one. At exactly 60 Hz it waited for a new guest scene instead. v2217 applies
+the same fixed cadence at 60 Hz. Re-presenting a completed image does not call
+or advance guest functions, timers, input, audio sequencing, or physics.
+
+## Build identity and checks
+
+Checkpoint executable SHA-256 (binary not distributed):
+
+`0F225655BF9F32C1FAEE76CF559EABD1D7D5C19A4960BD7A02B512582A4A08E6`
+
+The link-freshness verifier accepted all 116 objects. The native ELAN/Vulkan,
+render completion/DMA, card, AICA, and 837-13551 JVS/shifter tests passed.
+
+## Performance evidence
+
+At 3840×2160, 43 samples from race takeover onward measured:
+
+- minimum: 59.8 FPS
+- average: 60.000 FPS
+- maximum: 60.1 FPS
+
+The same synchronous sound-pack loads occurred without the earlier cadence
+collapse. Normal JVS/physics input drove the player 668.687 metres. The real
+DIMM path selected the tested course stream, and ARM7/AICA produced 7,942,187
+samples, including 6,719,814 non-silent samples. Automated QA stayed muted.
+
+At 1920×1080, ten operational takeover/race samples measured 119.8–120.1 FPS
+through 190.065 metres of motion. One 117.9 sample occurred later during the
+intentional watchdog shutdown dump while hundreds of diagnostic lines were
+being emitted; it is recorded as diagnostic overhead rather than hidden or
+misreported as gameplay performance.
+
+Both acceptance logs contain zero fatal, exception, access-violation,
+unimplemented-target, NSEQ, or Vulkan fault markers.
+
+## Remaining work
+
+1. Validate every mode, course, car, opponent, condition, outcome, continue/result path, and card-error branch.
+2. Reduce the underlying synchronous asset/music transition latency while preserving guest-visible ordering.
+3. Complete hardware acceptance for wheels, force feedback, audio devices, and controller remapping.
+4. Finish clean-machine preparation, crash reporting, settings polish, and legally safe release packaging.
+5. Protect 120 FPS across broader content, then pursue unlimited presentation without changing gameplay, timers, physics, or audio.
+
+This is substantial progress, not a completion claim. The public repository
+remains a source-safe engineering showcase rather than a playable game release.

--- a/docs/CURRENT_CHECKPOINT_2026-08-30.md
+++ b/docs/CURRENT_CHECKPOINT_2026-08-30.md
@@ -1,0 +1,81 @@
+# Current source-safe checkpoint — 2026-08-30
+
+This document reports the private v2374 integration checkpoint without
+publishing a game binary, generated game translation, ROM/BIOS/PIC/CHD data,
+assets, captures, logs, input recordings, save/card data, memory snapshots, or
+private host paths.
+
+## Project boundary
+
+- Target hardware: Sega NAOMI 2.
+- Execution model: native static ahead-of-time SH-4 recompilation.
+- Graphics API: Vulkan.
+- Authentic game logic, physics, timers, input, and audio cadence: 60 Hz.
+- Enhanced presentation target: distinct 120 Hz motion samples.
+- No interpreter, JIT, emulator runtime, fabricated game state, or replacement game assets.
+- The shipped private runtime is BIOS-free; firmware remains a development oracle, not a runtime dependency.
+
+## Reproducible cold-race slowdown
+
+The same resolved-input and disposable-card route was run on the private v2373
+product. It entered course `k_ez` at 102.2 seconds, produced no repeated moving
+endpoints and reported no faults, but the first full race intervals fell as low
+as 100 generated/display FPS. The 22 complete intervals averaged 116.609 FPS.
+
+Low-overhead timing and A/B runs ruled out Vulkan rendering, average ELAN
+capture cost, AICA, and presentation repetition. A guest-thread sampling run
+identified the game's canonical byte-wise memset while cold race objects were
+being allocated and initialized.
+
+## Exact v2374 repair
+
+The private translated integration now performs one host bulk fill only when
+the complete canonical destination range is proven to be ordinary main RAM.
+It preserves the translated routine's final registers and T flag and charges
+exactly one guest memory-access cycle per byte. Zero-length, device, VRAM,
+ELAN, host-aperture, and boundary-crossing cases retain the original path.
+
+No gameplay, physics, timer, audio, card, renderer, or presentation rule was
+changed.
+
+## Performance evidence
+
+The matching v2374 route entered the same `k_ez` course at 102.3 seconds.
+Across all 23 complete two-second race intervals:
+
+- minimum generated/display FPS: 120.0
+- average generated/display FPS: 120.0
+- minimum generated motion samples per interval: 120
+- moving-race repeat-counter delta: 0
+- fault markers: 0
+
+The result is distinct presentation interpolation over authentic 60 Hz guest
+state, not duplicated 60 Hz endpoints.
+
+## Build identity and checks
+
+Private checkpoint executable SHA-256 (binary not distributed):
+
+`81F18BBEA04D42B692BE295630A3F6A6DE8DF6F479ECF4881E38FCAC100FD0C4`
+
+Validation passed for:
+
+- exact bulk range/content/cycle behavior;
+- the exact linked translated memset across zero, one-byte, unaligned, and P1-alias cases;
+- custom music decoding/mixing and native audio integration;
+- presenter interpolation;
+- card/JVS, native ELAN, and VRAM aliases;
+- the exact card-eject jump-table classifier;
+- 360-frame Vulkan resize/presentation smoke coverage;
+- link freshness across 116 objects;
+- standalone BIOS-free audit with zero firmware dependencies.
+
+## Remaining work
+
+1. Repeat the cold distinct-120 gate across every course and heavy scene.
+2. Validate every mode, car, opponent, condition, outcome, continue/result path, and card-error branch.
+3. Complete physical wheel, force-feedback, controller, and audible-device acceptance.
+4. Finish clean-machine packaging, crash reporting, settings polish, and long-session stability.
+5. Pursue unlimited presentation only after the 120 Hz whole-game gate is protected.
+
+This is an accepted measured-route improvement, not a whole-game completion claim.

--- a/docs/CURRENT_CHECKPOINT_V2396_2026-08-30.md
+++ b/docs/CURRENT_CHECKPOINT_V2396_2026-08-30.md
@@ -1,4 +1,4 @@
-# Current source-safe checkpoint — v2396
+# Current source-safe checkpoint — v2396 product / v2399 QA
 
 Date: 2026-08-30
 
@@ -52,12 +52,23 @@ object name and accepts v2396 as fresh.
 - route/branch targets loaded: 48/48;
 - rival profiles with real movement: 32/32;
 - Time Trial layouts with natural results: 16/16;
-- rival profiles with natural results: 25/32; and
+- rival profiles with natural results: 32/32; and
 - four-course priority high-refresh matrix: passed with 119.8–120.0 FPS
   minimum presentation and no repeated endpoints in accepted moving windows.
 
-The seven remaining natural rival-result proofs are `r_evo5`, `r_keisuke2`,
-`r_kyoko`, `r_ryosuke2`, `r_sakamoto`, `r_sudo2`, and `r_wataru`.
+The final seven natural proofs covered `r_evo5`, `r_keisuke2`, `r_kyoko`,
+`r_ryosuke2`, `r_sakamoto`, `r_sudo2`, and `r_wataru`. Each target was
+identity-gated away from the prerequisite outcome helper and reached the
+game's real result asset through normal JVS input and guest physics. The final
+Keisuke2 and Sudo2 runs held approximately 60.0 FPS average Vulkan
+presentation and recorded no fatal, access-violation, unimplemented-target,
+or device-loss marker.
+
+Two later private QA-only controls made the last branches deterministic: a
+minimum-travel gate for a one-time navigation detour, and an outcome-count
+threshold for an existing absolute cabinet detent. Both are default-off,
+cleared between harness runs, and absent from ordinary product behavior. The
+accepted Desktop/product binary therefore remains v2396.
 
 ## Verified private candidate
 
@@ -69,8 +80,8 @@ The binary is intentionally not published.
 
 ## Honest remaining work
 
-- Finish the seven remaining natural rival-result proofs and broader long-run
-  campaign/error-path coverage.
+- Continue broader long-run campaign/error-path coverage now that all 32
+  natural rival-result proofs are complete.
 - Complete physical wheel/force-feedback and audible end-user acceptance.
 - Continue visual comparison across remaining car/course/weather combinations.
 - Reduce remaining synchronous transition latency.

--- a/docs/CURRENT_CHECKPOINT_V2396_2026-08-30.md
+++ b/docs/CURRENT_CHECKPOINT_V2396_2026-08-30.md
@@ -1,0 +1,78 @@
+# Current source-safe checkpoint — v2396
+
+Date: 2026-08-30
+
+This note reports private integration evidence without publishing game code,
+game data, firmware, extracted assets, cards, captures, or the executable.
+
+## Native architecture boundary
+
+The product path is a static SH-4 AOT runtime for NAOMI 2. Its standalone
+audit reports zero firmware callbacks, firmware AOT objects, firmware input
+contracts, and cached firmware translations. The launcher prepares required
+files only from matching user-owned game inputs and requires no installed
+Python runtime.
+
+## Custom BGM synchronization
+
+The separate held-View host picker has been removed. During the authentic
+opponent selector, a quick Change View press cycles cabinet entry 0/no music
+and original streams 1–13. When a selected slot has a user replacement, the
+small in-game label uses a sanitized version of that file's name. A cleared,
+missing, or invalid replacement draws no host title and keeps the original.
+
+A bounded BIOS-free route supplied two logical View edges during the real
+course-specific rival-face selector. The same run proved:
+
+- first press selected entry 0 with no custom title;
+- second press displayed `FLY TO ME TO THE MOON AND BACK` for slot 1;
+- the game's default request for stream 5 resolved to original stream 1;
+- the replacement decoded successfully;
+- the authentic AICA stream-start command activated the replacement mixer;
+- Vulkan presentation held 60.0 Hz through live movement; and
+- no fatal, access-violation, unimplemented-target, ELAN, or Vulkan fault was
+  recorded before the intentional watchdog stop.
+
+The example filename describes private test evidence only; no audio file is in
+this repository.
+
+## Link-freshness repair
+
+An inline asset-loading shim was selected by the linker from one translated
+COMDAT owner. Rebuilding only the ordinary product-facing translation units
+left that owner stale, making a source change visible in tests but absent from
+the executable. v2396 explicitly rebuilds the owning object.
+
+The source-safe build verifier now rejects an owner object older than the
+inline headers it owns. It identifies the historical stale build by exact
+object name and accepts v2396 as fresh.
+
+## Current coverage ledger
+
+- route/branch targets loaded: 48/48;
+- rival profiles with real movement: 32/32;
+- Time Trial layouts with natural results: 16/16;
+- rival profiles with natural results: 25/32; and
+- four-course priority high-refresh matrix: passed with 119.8–120.0 FPS
+  minimum presentation and no repeated endpoints in accepted moving windows.
+
+The seven remaining natural rival-result proofs are `r_evo5`, `r_keisuke2`,
+`r_kyoko`, `r_ryosuke2`, `r_sakamoto`, `r_sudo2`, and `r_wataru`.
+
+## Verified private candidate
+
+SHA-256:
+
+`966F218E54CC2C3A112D174163C85B141DDA25FE96836729D310E8773C555E91`
+
+The binary is intentionally not published.
+
+## Honest remaining work
+
+- Finish the seven remaining natural rival-result proofs and broader long-run
+  campaign/error-path coverage.
+- Complete physical wheel/force-feedback and audible end-user acceptance.
+- Continue visual comparison across remaining car/course/weather combinations.
+- Reduce remaining synchronous transition latency.
+- Treat unlimited presentation as future work after the 120 FPS compatibility
+  matrix is exhaustive.

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -9,11 +9,11 @@ These files are selected from the private integration tree to show the real clea
 
 Only `native_elan_bridge.h` is compiled by the standalone public smoke test. The decoder/renderer snapshots refer to support headers in the private integration tree and are included for review, not as a claim that this repository is a complete runtime.
 
-The private v2216 integration tree has advanced beyond these selected snapshots
+The private v2217 integration tree has advanced beyond these selected snapshots
 with targeted menu-to-race/result/save execution, corrected HUD and mirror
 projection, additional PVR list features, native AICA/Maple/JVS/card tests,
-persistent renderer workers, Vulkan pipeline prewarming, and asset-lineage
-validation. These components will be moved into this public tree only when they
+persistent renderer workers, Vulkan pipeline prewarming, fixed 60 Hz retained
+presentation during guest loads, and asset-lineage validation. These components will be moved into this public tree only when they
 can be separated cleanly from generated game code and private captures without
 weakening the legal boundary.
 

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -9,10 +9,12 @@ These files are selected from the private integration tree to show the real clea
 
 Only `native_elan_bridge.h` is compiled by the standalone public smoke test. The decoder/renderer snapshots refer to support headers in the private integration tree and are included for review, not as a claim that this repository is a complete runtime.
 
-The private integration tree has advanced beyond these selected snapshots with
-continuous submitted-scene presentation, additional PVR list features, native
-AICA/Maple tests, and asset-lineage validation. Those components will be moved
-into this public tree only when they can be separated cleanly from generated
-game code and private captures without weakening the legal boundary.
+The private v2216 integration tree has advanced beyond these selected snapshots
+with targeted menu-to-race/result/save execution, corrected HUD and mirror
+projection, additional PVR list features, native AICA/Maple/JVS/card tests,
+persistent renderer workers, Vulkan pipeline prewarming, and asset-lineage
+validation. These components will be moved into this public tree only when they
+can be separated cleanly from generated game code and private captures without
+weakening the legal boundary.
 
 Generated game translations, memory/device integration, private replay code, asset inputs, and compatibility-only experiments are intentionally excluded.


### PR DESCRIPTION
## Summary
- documents the BIOS-free v2396 private integration checkpoint
- records opponent-menu custom-BGM title/stream synchronization
- publishes current route, rival-result, and 120 FPS validation coverage
- documents the stale inline-COMDAT owner safeguard

## Public-safety boundary
Documentation only. No executable, game data, firmware, generated guest code, cards, logs, captures, or user music is included.

## Validation
- source-safe Python tests: 5/5 passed
- native CTest: 1/1 passed
- git diff whitespace check passed