### PR TITLE
Publish v2440 GPU presentation checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v2440-gpu-presentation — 2026-09-01
+
+- Moved PVR depth normalization into the Vulkan vertex shader.
+- Replaced CPU-staged vertex/index arrays with two bounded regions inside the
+  persistent mapped Vulkan geometry buffers.
+- Replaced CPU-staged ELAN projection/lighting uniforms with two aligned mapped
+  regions inside the existing uniform allocation.
+- Preserved exact adjacent-state reuse and fail-closed overflow handling for
+  geometry, topology, and uniform streams.
+- Added a native BGRA fallback contract so compatible Vulkan readback can be
+  copied directly into a Win32 32-bit DIB without a per-pixel 4-to-3-byte
+  conversion loop.
+- Added Direct Vulkan unclean-session protection: an interrupted Direct run
+  automatically falls back to the host-safe presentation path on next start.
+- Passed the complete controller, music, interpolation, card, renderer,
+  lifecycle, translation-freshness, and BIOS-free product suite.
+- Completed a live 2560x1080 Direct Vulkan course/result run at sustained
+  119.7–120.3 presentation FPS, bounded memory/handles, exit code 0, complete
+  renderer/audio/input teardown, and clean crash-marker removal.
+- Kept the public v2415 demo as the current downloadable prerelease while the
+  v2440 integration checkpoint receives broader hardware and route coverage.
+
 ## v2415-host-safety — 2026-08-31
 
 - Added a process-wide single-instance guard so a second recomp exits before

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 Public ZIP SHA-256:
 `8CA9D017EA5BCFE8EB58245D162D89A22D75267BC6D3BABAD76D922E283B2E8E`
 
-## Current v2415 features
+## Current integration progress (v2440 WIP)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -73,6 +73,12 @@ Public ZIP SHA-256:
   renderer drain as a normal close.
 - Bounded Vulkan acquire, graphics-fence, presentation-fence, and startup
   upload waits; no queue-idle, device-idle, or infinite fence wait remains.
+- Direct Vulkan presentation now bypasses the CPU/GDI display copy when the
+  user explicitly selects it. A clean-session marker automatically falls back
+  to Safe presentation after an interrupted Direct session.
+- GPU projection, ELAN lighting, depth normalization, static-geometry reuse,
+  packed topology, and persistent mapped geometry/uniform streams remove the
+  previous per-frame CPU staging copies.
 
 ## Verified progress
 
@@ -94,6 +100,15 @@ Public ZIP SHA-256:
   Vulkan, card-eject classification, translation integrity, link freshness,
   the no-firmware product boundary, cooperative QA shutdown, and single-instance
   enforcement.
+- The v2440 integration build passed the same complete offline suite and a live
+  RX 9070 XT Direct Vulkan run. A 75,000–127,000-vertex course/race sequence
+  sustained 119.7–120.3 visible presents per second, generated distinct
+  intermediate motion, crossed into the result/continue transition, and then
+  completed every cooperative shutdown phase with exit code 0.
+- During that live run the Direct path reduced sampled renderer/process CPU
+  demand from roughly 1.56 host cores in Safe/GDI presentation to 0.2–1.2
+  cores depending on scene load. Memory and handle counts stabilized, and the
+  Direct-session marker was removed on normal exit.
 - A cross-machine renderer replay produced the same accepted frame SHA-256:
   `34D6B91C0550A5CC2A60D4B1F8930812908CEA6DCD6C354749A0881BE426D9E2`.
 
@@ -126,9 +141,10 @@ failure, and the newest logs. Do not upload game files, extracted assets, card
 data, or copyrighted music.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
-[the v2415 checkpoint](docs/CURRENT_CHECKPOINT_V2415_2026-08-31.md) for the
-current release facts, and [ROADMAP.md](ROADMAP.md) for the ordered acceptance
-criteria.
+[the v2440 integration checkpoint](docs/CURRENT_CHECKPOINT_V2440_2026-09-01.md)
+for the latest source/runtime facts, [the v2415 checkpoint](docs/CURRENT_CHECKPOINT_V2415_2026-08-31.md)
+for the current public-release facts, and [ROADMAP.md](ROADMAP.md) for the
+ordered acceptance criteria.
 
 ## Repository contents
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,23 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
+## Current integration checkpoint — v2440 GPU presentation
+
+- Direct Vulkan presentation bypasses the Safe path's CPU/GDI display boundary
+  when explicitly selected.
+- Projection, ELAN lighting, normalized depth, static geometry/topology, and
+  per-object uniform data now use GPU-side work or bounded persistent mapped
+  streams instead of per-frame CPU staging copies.
+- A compatible Safe-mode BGRA readback can be copied directly into a Win32
+  32-bit DIB; diagnostics retain exact RGB24 output.
+- An interrupted Direct session leaves a marker that forces the next launch
+  back to Safe presentation.
+- One live 2560x1080 RX 9070 XT run sustained 119.7–120.3 FPS through a heavy
+  course and result transition, then exited normally and removed the marker.
+
+Checkpoint result: the newest Direct run is host-clean and meets its measured
+120 Hz target; broader route and cross-driver stress is still required.
+
 ## Published checkpoint — v2415 public early demo
 
 - A Windows x64 package now verifies matching user-owned CHD/PIC inputs,
@@ -34,6 +51,8 @@ not release-ready.
   smoothing, and launcher-setting regressions.
 - Complete a conservative live Vulkan close/restart stress pass only after the
   offline shutdown gates remain green.
+- Preserve the passing Direct-session marker lifecycle and v2440 clean live
+  shutdown while extending the matrix across more hardware and restart cycles.
 
 Acceptance: supported controllers are detected and remappable on a clean
 machine, and repeated normal close/restart cycles leave no live renderer/audio

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
-Status date: 2026-08-31
-Integration checkpoint: v2415 WIP
+Status date: 2026-09-01
+Integration checkpoint: v2440 WIP
 Public checkpoint: v2415 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -17,11 +17,27 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, digital shifter routes, XInput-first device selection, hotplug rescan, paused-menu remapping, adjustable FFB, and saved 0–100% steering smoothing pass focused tests | Physical controller, wheel, and FFB acceptance across hardware remains open |
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload on a tested Legend flow | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
-| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; the four-course priority matrix held 119.8–120.0 FPS minimum with zero accepted moving-race repeats | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
-| Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, and single-instance enforcement pass source/offscreen checks; route-only QA defaults to no Vulkan WSI | Live Win32 WSI stress across GPUs/drivers remains pending and is not replaced by offscreen evidence |
+| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, and Direct Vulkan display are active. The v2440 live course/result run held 119.7–120.3 FPS with distinct intermediate motion | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
+| Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. One sustained v2440 live Direct run completed exit code 0 and removed its session marker | Repeated live close/restart stress across more GPUs/drivers remains open |
 | Distribution | A BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs and performs verification/extraction locally | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
+
+- v2440 native executable SHA-256: `7FB61B45A0137F8FCE4A9A6CD36200B212F7DFDC6717D851739AD9CBB4D798BC` (binary intentionally not published).
+- The complete offline suite passed CPU/Vulkan pixel comparison, topology,
+  projection, ELAN lighting, environment mapping, homogeneous near clipping,
+  16,384-static-vertex reuse, controllers, custom music, interpolation, cards,
+  Direct-session marker lifecycle, 31 shutdown/presentation policies, 13
+  controller/music policies, guest timing, link freshness, and the no-firmware
+  standalone audit.
+- A live 2560x1080 RX 9070 XT Direct Vulkan run sustained 119.7–120.3 FPS
+  across roughly 75,000–127,000 vertices per authentic course frame. During
+  moving content the generated-frame count advanced at the required cadence
+  and the repeated-frame counter stayed effectively flat.
+- The v2440 process crossed the result/continue transition, stabilized near a
+  1.34 GiB working set with zero handle growth in the steady sample, exited 0,
+  completed renderer/audio/DirectInput/window teardown, and removed its
+  Direct-session marker.
 
 - v2415 native executable SHA-256: `3185FF67F00EE5E8EF17E63F5B10ECDF66494B3B604358ED7DA863C7AB56B8D4`.
 - Public ZIP SHA-256: `8CA9D017EA5BCFE8EB58245D162D89A22D75267BC6D3BABAD76D922E283B2E8E`; local audited size is 17,877,033 bytes.
@@ -71,12 +87,12 @@ corrected the tested HUD projection, mirror placement, RX-7 geometry/texture
 failures, and renderer lifecycle defects. This does not imply that all graphics
 or gameplay paths are complete.
 
-The current priority frontier is broad physical-input acceptance, conservative host
-shutdown validation, whole-game same-build coverage, remaining visual/audio
-defects, reducing synchronous transition latency, broader clean-machine
-packaging, and eventually uncapped presentation that stays independent from
-guest gameplay timing. The measured high-refresh routes do not make 120 Hz a
-whole-game validated mode.
+The current priority frontier is reducing remaining CPU command preparation,
+broad physical-input acceptance, repeated cross-driver shutdown validation,
+whole-game same-build coverage, remaining visual/audio defects, synchronous
+transition latency, broader clean-machine packaging, and eventually uncapped
+presentation that stays independent from guest gameplay timing. The measured
+high-refresh routes do not make 120 Hz a whole-game validated mode.
 
 ## Definition of release-ready
 

--- a/docs/CURRENT_CHECKPOINT_V2440_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2440_2026-09-01.md
@@ -1,0 +1,91 @@
+# Current checkpoint — v2440 GPU presentation
+
+Date: 2026-09-01
+
+This is an integration checkpoint. The latest downloadable public early demo
+remains v2415 while v2440 receives broader route and hardware testing.
+
+## What changed
+
+The remaining high-volume renderer staging work was reduced without changing
+the original game's simulation cadence:
+
+- PVR screen-depth normalization moved to the Vulkan vertex shader.
+- Vertex and index output now writes directly into alternating bounded regions
+  of persistent mapped Vulkan buffers.
+- ELAN projection and lighting records now write directly into alternating
+  aligned regions of the existing mapped uniform buffer.
+- Exact adjacent object-state reuse remains enabled, and every stream rejects
+  overflow rather than aliasing an in-flight region.
+- Compatible BGRA8 fallback readback uses one bulk copy into a Win32 32-bit
+  DIB instead of repacking every pixel into BGR24.
+- Direct Vulkan presentation bypasses the GDI display copy. An unclean-session
+  marker forces a later launch back to Safe presentation if Direct presentation
+  does not finish normal shutdown.
+
+Gameplay, physics, racing AI, timers, input, and audio remain CPU-side at the
+authentic guest cadence. The work above changes graphics preparation and
+display delivery, not game behavior.
+
+## Product identity
+
+- Private integration executable SHA-256:
+  `7FB61B45A0137F8FCE4A9A6CD36200B212F7DFDC6717D851739AD9CBB4D798BC`
+- The binary is intentionally not committed to Git.
+- Standalone audit: zero firmware callbacks, firmware objects, firmware input
+  contracts, or cached firmware translations.
+
+## Offline verification
+
+The v2440 build passed:
+
+- CPU/Vulkan pixel comparisons;
+- primitive restart, strips, fans, flat fallback, and ordered translucency;
+- object projection, ELAN lighting, environment mapping, and homogeneous near
+  clipping;
+- the 64-batch / 16,384-static-vertex reuse and bulk path;
+- controller binding/capture and steering-smoothing checks;
+- exact custom-music decode and stream selection;
+- 120 Hz interpolation checks;
+- card persistence and eject classification;
+- the real Direct-session marker lifecycle test;
+- 31 restart/shutdown/presentation policies;
+- 13 controller/music policies;
+- exact guest delay/assertion timing and idle-wait policy;
+- link freshness for 116 product objects with zero stale direct sources; and
+- the BIOS-free standalone audit.
+
+## Live Direct Vulkan evidence
+
+A visible 2560x1080 run on an RX 9070 XT used a three-image FIFO Direct Vulkan
+swapchain and crossed a heavy course into the result/continue sequence.
+
+- Presentation stayed between 119.7 and 120.3 FPS during the accepted course
+  samples.
+- Authentic course frames contained roughly 75,000–127,000 vertices.
+- During moving content, intermediate-frame generation advanced at the required
+  cadence and the repeated-frame counter stayed effectively flat.
+- Sampled CPU demand ranged from about 0.2 host cores on light screens to about
+  1.2 cores in the heavy course scene.
+- After asset loading, working memory stabilized near 1.34 GiB. A 25-second
+  steady sample changed by +0.5 MiB working set, -1 MiB private memory, and zero
+  handles.
+- Opening F1 intentionally paused guest execution; normal 120 Hz course output
+  resumed immediately when the menu closed.
+- No Vulkan fault, device loss, fatal error, process hang, or host failure was
+  recorded.
+- The process exited with code 0. Raster helpers, audio, DirectInput, the raster
+  worker, and the window all completed normal shutdown.
+- The Direct-session marker was removed on exit.
+
+## Current boundary
+
+This successful run materially strengthens the Direct Vulkan and shutdown
+evidence, but it is not whole-game or cross-driver proof. Remaining work is to
+profile the residual CPU command-preparation path, extend visual/interpolation
+checks across content, repeat live close/restart testing on more hardware, and
+complete audio, input, card, route, and clean-machine acceptance.
+
+No game image, BIOS, PIC, CHD, extracted asset, card, music, capture, log,
+translated guest body, executable, object file, or personal filesystem path is
+included in this checkpoint.


### PR DESCRIPTION
## Summary
- document the v2437-v2440 GPU depth, mapped geometry/uniform, and native BGRA presentation work
- record the validated 2560x1080 Direct Vulkan 120 Hz course/result run and clean shutdown marker lifecycle
- update README, status ledger, roadmap, and changelog while keeping v2415 as the current public demo

## Public boundary
Documentation only. No executable, translated guest body, game data, BIOS, PIC, CHD, extracted asset, card, music, capture, log, credential, or personal path is included.

## Validation
- python -m unittest discover -s tests -v
- cmake -S . -B build-v2440-docs
- cmake --build build-v2440-docs --config Release
- ctest --test-dir build-v2440-docs -C Release --output-on-failure
- public content/path audit