### PR TITLE
Publish v2441 static topology checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   lifecycle, link-freshness, timing, and BIOS-free standalone suite.
 - Passed conservative CPU-only cold-boot/movement probes for Myogi Time Attack
   (left/dry/day), Usui Time Attack (right/wet/night), and Shomaru Bunta, each
-  with correct assets/conditions and cooperative exit.
+  plus Tsuchisaka Bunta, each with correct assets/conditions and cooperative
+  exit.
 - Corrected the private route-evidence parser to recognize the segmented
   `*_pol_a/b/c.tbl` geometry used by Shomaru while still excluding condition
   meshes from primary-course identification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v2441-static-topology-cache — 2026-09-01
+
+- Cached immutable connector, fan, point-validity, and UV-readiness summaries
+  beside exact-matched static Vulkan points and packed topology.
+- Kept the established full validation/rebuild path for changed, animated,
+  screen-space, diagnostic, modifier, and unsupported geometry.
+- Added an explicit presenter contract test proving BGR24 and direct BGRA32
+  output decode pixel-identically to the ordinary RGB diagnostic result.
+- Reduced median topology preparation by 35.9% and the complete controlled
+  16,384-vertex static-reuse frame by 9.6% across seven fresh-process samples.
+- Passed the complete offline correctness, input, audio, card, interpolation,
+  lifecycle, link-freshness, timing, and BIOS-free standalone suite.
+- Kept v2415 as the current downloadable public early demo; v2441 is an
+  integration checkpoint pending broader live route and hardware acceptance.
+
 ## v2440-gpu-presentation — 2026-09-01
 
 - Moved PVR depth normalization into the Vulkan vertex shader.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@
 - Passed the complete offline correctness, input, audio, card, interpolation,
   lifecycle, link-freshness, timing, and BIOS-free standalone suite.
 - Passed conservative CPU-only cold-boot/movement probes for Myogi Time Attack
-  and Shomaru Bunta, each with correct assets/conditions and cooperative exit.
+  (left/dry/day), Usui Time Attack (right/wet/night), and Shomaru Bunta, each
+  with correct assets/conditions and cooperative exit.
 - Corrected the private route-evidence parser to recognize the segmented
   `*_pol_a/b/c.tbl` geometry used by Shomaru while still excluding condition
   meshes from primary-course identification.
+- Made the private runner compatible with retained manifests that predate the
+  numeric direction column by deriving the generator's exact Left=0/Right=1
+  mapping from the explicit label.
 - Kept v2415 as the current downloadable public early demo; v2441 is an
   integration checkpoint pending broader live route and hardware acceptance.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   16,384-vertex static-reuse frame by 9.6% across seven fresh-process samples.
 - Passed the complete offline correctness, input, audio, card, interpolation,
   lifecycle, link-freshness, timing, and BIOS-free standalone suite.
+- Passed conservative CPU-only cold-boot/movement probes for Myogi Time Attack
+  and Shomaru Bunta, each with correct assets/conditions and cooperative exit.
+- Corrected the private route-evidence parser to recognize the segmented
+  `*_pol_a/b/c.tbl` geometry used by Shomaru while still excluding condition
+  meshes from primary-course identification.
 - Kept v2415 as the current downloadable public early demo; v2441 is an
   integration checkpoint pending broader live route and hardware acceptance.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 Public ZIP SHA-256:
 `8CA9D017EA5BCFE8EB58245D162D89A22D75267BC6D3BABAD76D922E283B2E8E`
 
-## Current integration progress (v2440 WIP)
+## Current integration progress (v2441 WIP)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -79,6 +79,9 @@ Public ZIP SHA-256:
 - GPU projection, ELAN lighting, depth normalization, static-geometry reuse,
   packed topology, and persistent mapped geometry/uniform streams remove the
   previous per-frame CPU staging copies.
+- Exact-matched static course/car batches retain their immutable topology
+  eligibility summaries, avoiding repeated full-array scans on each 120 Hz
+  presentation phase.
 
 ## Verified progress
 
@@ -100,11 +103,12 @@ Public ZIP SHA-256:
   Vulkan, card-eject classification, translation integrity, link freshness,
   the no-firmware product boundary, cooperative QA shutdown, and single-instance
   enforcement.
-- The v2440 integration build passed the same complete offline suite and a live
-  RX 9070 XT Direct Vulkan run. A 75,000–127,000-vertex course/race sequence
-  sustained 119.7–120.3 visible presents per second, generated distinct
-  intermediate motion, crossed into the result/continue transition, and then
-  completed every cooperative shutdown phase with exit code 0.
+- The v2441 integration build passed the same complete offline suite, including
+  a new BGR24/BGRA32 presenter channel-accuracy test. In the preceding v2440
+  live RX 9070 XT Direct Vulkan run, a 75,000–127,000-vertex course/race
+  sequence sustained 119.7–120.3 visible presents per second, generated
+  distinct intermediate motion, crossed into the result/continue transition,
+  and then completed every cooperative shutdown phase with exit code 0.
 - During that live run the Direct path reduced sampled renderer/process CPU
   demand from roughly 1.56 host cores in Safe/GDI presentation to 0.2–1.2
   cores depending on scene load. Memory and handle counts stabilized, and the
@@ -141,7 +145,7 @@ failure, and the newest logs. Do not upload game files, extracted assets, card
 data, or copyrighted music.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
-[the v2440 integration checkpoint](docs/CURRENT_CHECKPOINT_V2440_2026-09-01.md)
+[the v2441 integration checkpoint](docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md)
 for the latest source/runtime facts, [the v2415 checkpoint](docs/CURRENT_CHECKPOINT_V2415_2026-08-31.md)
 for the current public-release facts, and [ROADMAP.md](ROADMAP.md) for the
 ordered acceptance criteria.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## Current integration checkpoint — v2440 GPU presentation
+## Current integration checkpoint — v2441 static topology cache
 
 - Direct Vulkan presentation bypasses the Safe path's CPU/GDI display boundary
   when explicitly selected.
@@ -15,9 +15,16 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
   back to Safe presentation.
 - One live 2560x1080 RX 9070 XT run sustained 119.7–120.3 FPS through a heavy
   course and result transition, then exited normally and removed the marker.
+- v2441 retains immutable topology eligibility summaries for exact-matched
+  static geometry. In the controlled 16,384-vertex reuse case this reduced
+  median topology preparation by 35.9% and complete frame time by 9.6%.
+- The complete offline suite, including direct BGR24/BGRA32 channel validation,
+  remains green. The live 120 Hz and clean-exit result above is from v2440;
+  v2441 still needs broader live acceptance rather than another forced launch.
 
-Checkpoint result: the newest Direct run is host-clean and meets its measured
-120 Hz target; broader route and cross-driver stress is still required.
+Checkpoint result: the newest Direct run is host-clean, the bounded v2441 CPU
+optimization is measured and regression-clean, and broader route/cross-driver
+stress is still required.
 
 ## Published checkpoint — v2415 public early demo
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -34,6 +34,9 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
   9.548 m of player movement and Shomaru dry/night Bunta with 5.097 m. Both
   identified the expected course/condition/environment assets and exited 0
   through cooperative close without creating a Vulkan WSI surface.
+- A complementary Usui right/wet/night Time Attack probe loaded the expected
+  course, reverse condition geometry, direction identity `1,1,1`, night
+  environment, and rain; it advanced 9.008 m and exited cooperatively with 0.
 - v2440 native executable SHA-256: `7FB61B45A0137F8FCE4A9A6CD36200B212F7DFDC6717D851739AD9CBB4D798BC` (binary intentionally not published).
 - The complete offline suite passed CPU/Vulkan pixel comparison, topology,
   projection, ELAN lighting, environment mapping, homogeneous near clipping,

--- a/STATUS.md
+++ b/STATUS.md
@@ -37,6 +37,9 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 - A complementary Usui right/wet/night Time Attack probe loaded the expected
   course, reverse condition geometry, direction identity `1,1,1`, night
   environment, and rain; it advanced 9.008 m and exited cooperatively with 0.
+- Tsuchisaka dry/night Bunta likewise loaded `k_tu2`, its forward condition
+  geometry, night/no-rain environment, and the Bunta rival package; it advanced
+  6.302 m and exited cooperatively with 0.
 - v2440 native executable SHA-256: `7FB61B45A0137F8FCE4A9A6CD36200B212F7DFDC6717D851739AD9CBB4D798BC` (binary intentionally not published).
 - The complete offline suite passed CPU/Vulkan pixel comparison, topology,
   projection, ELAN lighting, environment mapping, homogeneous near clipping,

--- a/STATUS.md
+++ b/STATUS.md
@@ -30,6 +30,10 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 - v2441 passed the complete v2440 offline suite plus an explicit BGR24/BGRA32
   presenter channel-accuracy contract. Its standalone audit remains at zero
   firmware callbacks, AOT objects, input contracts, and cached translations.
+- v2441 CPU-only cold-boot probes passed Myogi left/dry/day Time Attack with
+  9.548 m of player movement and Shomaru dry/night Bunta with 5.097 m. Both
+  identified the expected course/condition/environment assets and exited 0
+  through cooperative close without creating a Vulkan WSI surface.
 - v2440 native executable SHA-256: `7FB61B45A0137F8FCE4A9A6CD36200B212F7DFDC6717D851739AD9CBB4D798BC` (binary intentionally not published).
 - The complete offline suite passed CPU/Vulkan pixel comparison, topology,
   projection, ELAN lighting, environment mapping, homogeneous near clipping,

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2440 WIP
+Integration checkpoint: v2441 WIP
 Public checkpoint: v2415 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -17,12 +17,19 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, digital shifter routes, XInput-first device selection, hotplug rescan, paused-menu remapping, adjustable FFB, and saved 0–100% steering smoothing pass focused tests | Physical controller, wheel, and FFB acceptance across hardware remains open |
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload on a tested Legend flow | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
-| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, and Direct Vulkan display are active. The v2440 live course/result run held 119.7–120.3 FPS with distinct intermediate motion | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
+| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. The v2440 live course/result run held 119.7–120.3 FPS with distinct intermediate motion; v2441 reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
 | Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. One sustained v2440 live Direct run completed exit code 0 and removed its session marker | Repeated live close/restart stress across more GPUs/drivers remains open |
 | Distribution | A BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs and performs verification/extraction locally | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
 
+- v2441 native executable SHA-256: `78FFA018D058744A5AA5AAF5F5580C09F313CB8F5725A744AD0BFBCD6E30C6DD` (binary intentionally not published).
+- Seven fresh-process samples of the warmed 16,384-vertex reuse case reduced
+  median batch-loop time from 0.089 ms to 0.066 ms, topology time from 0.064 ms
+  to 0.041 ms, and complete synthetic frame time from 0.696 ms to 0.629 ms.
+- v2441 passed the complete v2440 offline suite plus an explicit BGR24/BGRA32
+  presenter channel-accuracy contract. Its standalone audit remains at zero
+  firmware callbacks, AOT objects, input contracts, and cached translations.
 - v2440 native executable SHA-256: `7FB61B45A0137F8FCE4A9A6CD36200B212F7DFDC6717D851739AD9CBB4D798BC` (binary intentionally not published).
 - The complete offline suite passed CPU/Vulkan pixel comparison, topology,
   projection, ELAN lighting, environment mapping, homogeneous near clipping,

--- a/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
@@ -59,6 +59,9 @@ Conservative CPU-only cold-boot probes also passed two real route families:
 - Usui right/wet/night Time Attack loaded `s_nm2`, the reverse condition mesh,
   all three right-direction guest flags, night environment, and rain; normal
   guest input/physics advanced 9.008 m.
+- Tsuchisaka dry/night Bunta loaded `k_tu2`, its forward condition mesh,
+  night/no-rain environment, and the Bunta rival package; normal guest
+  input/physics advanced 6.302 m.
 
 Each probe ran Below Normal with Vulkan disabled and one offscreen preview
 frame per second, then used cooperative close after movement and exited 0. The

--- a/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
@@ -56,12 +56,17 @@ Conservative CPU-only cold-boot probes also passed two real route families:
 - Shomaru dry/night Bunta loaded segmented `n_sy2` course geometry, the forward
   condition mesh, night environment, no rain, and the Bunta rival package;
   normal guest input/physics advanced 5.097 m.
+- Usui right/wet/night Time Attack loaded `s_nm2`, the reverse condition mesh,
+  all three right-direction guest flags, night environment, and rain; normal
+  guest input/physics advanced 9.008 m.
 
 Each probe ran Below Normal with Vulkan disabled and one offscreen preview
 frame per second, then used cooperative close after movement and exited 0. The
 route-evidence parser was corrected to recognize Shomaru's authentic segmented
 `*_pol_a/b/c.tbl` geometry without treating its separate condition mesh as the
-primary course.
+primary course. The runner also now derives Left=0/Right=1 from the explicit
+label when a retained manifest predates the generator's numeric direction
+column.
 
 Executable SHA-256:
 `78FFA018D058744A5AA5AAF5F5580C09F313CB8F5725A744AD0BFBCD6E30C6DD`

--- a/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
@@ -49,6 +49,20 @@ v2441 passed the complete offline suite covering:
 - a standalone audit with zero firmware callbacks, firmware AOT objects,
   firmware input contracts, or firmware translations in product caches.
 
+Conservative CPU-only cold-boot probes also passed two real route families:
+
+- Myogi left/dry/day Time Attack loaded `k_ez`, the forward condition mesh,
+  day environment, and no rain; normal guest input/physics advanced 9.548 m.
+- Shomaru dry/night Bunta loaded segmented `n_sy2` course geometry, the forward
+  condition mesh, night environment, no rain, and the Bunta rival package;
+  normal guest input/physics advanced 5.097 m.
+
+Each probe ran Below Normal with Vulkan disabled and one offscreen preview
+frame per second, then used cooperative close after movement and exited 0. The
+route-evidence parser was corrected to recognize Shomaru's authentic segmented
+`*_pol_a/b/c.tbl` geometry without treating its separate condition mesh as the
+primary course.
+
 Executable SHA-256:
 `78FFA018D058744A5AA5AAF5F5580C09F313CB8F5725A744AD0BFBCD6E30C6DD`
 

--- a/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
@@ -1,0 +1,66 @@
+# Current checkpoint — v2441 static topology cache
+
+Date: 2026-09-01
+
+This is an integration checkpoint. The latest downloadable public early demo
+remains v2415 while v2441 receives broader route and hardware testing.
+
+## What changed after v2440
+
+v2440 already moved projection, ELAN lighting, normalized depth, packed
+geometry/index streams, object uniforms, and Direct presentation onto bounded
+Vulkan paths. Profiling then isolated a smaller remaining host cost: unchanged
+course and car batches repeatedly scanned every retained point to rediscover
+the same connector, fan, point-validity, and UV-readiness answers before
+submitting already-packed geometry.
+
+v2441 stores those immutable predicates beside the exact-matched static point
+cache. A changed vertex/material payload, unsupported topology, animation,
+screen-space/HUD draw, diagnostic mode, modifier path, or failed eligibility
+check still takes the established full validation and rebuild path.
+
+## Controlled timing result
+
+Seven fresh-process samples of the warmed 16,384-vertex static reuse case:
+
+| Metric | v2440 median | v2441 median | Change |
+| --- | ---: | ---: | ---: |
+| Batch loop | 0.089 ms | 0.066 ms | -25.8% |
+| Topology preparation | 0.064 ms | 0.041 ms | -35.9% |
+| Complete synthetic frame | 0.696 ms | 0.629 ms | -9.6% |
+
+These are controlled renderer timings, not a claim that every game screen is
+9.6% faster. The preceding v2440 live Direct run had already sustained
+119.7–120.3 visible presents per second through a heavy course/result sequence.
+
+## Validation
+
+v2441 passed the complete offline suite covering:
+
+- CPU/Vulkan pixel comparisons and static cache/bulk submission;
+- strips, fans, flat shading, translucency, clipping, projection, lighting,
+  environment mapping, textures, and depth;
+- controller discovery/bindings/smoothing, custom music, cards, and
+  high-refresh interpolation;
+- Direct-session marker lifecycle, cooperative shutdown policies, guest
+  timing, idle waits, link freshness, and translation-source integrity;
+- a new BGR24/direct-BGRA32 presenter contract whose decoded channels are
+  pixel-identical to ordinary RGB output; and
+- a standalone audit with zero firmware callbacks, firmware AOT objects,
+  firmware input contracts, or firmware translations in product caches.
+
+Executable SHA-256:
+`78FFA018D058744A5AA5AAF5F5580C09F313CB8F5725A744AD0BFBCD6E30C6DD`
+
+The executable is intentionally not published from this integration
+checkpoint. No game data, firmware, PIC/CHD input, extracted asset, card save,
+custom music, capture, log, personal path, or generated game translation unit
+is included in this repository update.
+
+## Current boundary
+
+The public v2415 package remains the cautious playtest download at 60 FPS.
+v2441 improves a measured CPU preparation path, but 120 Hz is still
+experimental, uncapped presentation is unfinished, and exhaustive route,
+controller/wheel, audio, card-error, clean-machine, and cross-driver acceptance
+remains open.


### PR DESCRIPTION
Documents the measured v2441 static-topology cache optimization and its complete offline validation. Keeps v2415 as the current downloadable public early demo. This change contains documentation only and no game data, firmware, extracted assets, saves, music, logs, captures, binaries, or generated guest translation units.