### PR TITLE
Document v2441 ultrawide 120 Hz acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,17 @@ Public ZIP SHA-256:
   the no-firmware product boundary, cooperative QA shutdown, and single-instance
   enforcement.
 - The v2441 integration build passed the same complete offline suite, including
-  a new BGR24/BGRA32 presenter channel-accuracy test. In the preceding v2440
-  live RX 9070 XT Direct Vulkan run, a 75,000–127,000-vertex course/race
-  sequence sustained 119.7–120.3 visible presents per second, generated
-  distinct intermediate motion, crossed into the result/continue transition,
-  and then completed every cooperative shutdown phase with exit code 0.
+  a new BGR24/BGRA32 presenter channel-accuracy test. Four fresh v2441
+  Direct-Vulkan route runs then completed cooperative shutdown with exit code
+  0 and zero moving-race repeats. The exact 2560x1080 Akagi target sustained
+  120.0 FPS minimum/average for both display and Vulkan across 35 steady
+  two-second samples, with 120 distinct generated motion samples minimum per
+  bucket. Myogi and Akina/Akagi 640x480 controls measured 119.0–120.0 FPS
+  minimum and also recorded zero steady-race repeats.
+- In the preceding v2440 live RX 9070 XT Direct Vulkan run, a
+  75,000–127,000-vertex course/race sequence sustained 119.7–120.3 visible
+  presents per second, crossed into the result/continue transition, and then
+  completed every cooperative shutdown phase with exit code 0.
 - During that live run the Direct path reduced sampled renderer/process CPU
   demand from roughly 1.56 host cores in Safe/GDI presentation to 0.2–1.2
   cores depending on scene load. Memory and handle counts stabilized, and the

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,7 +17,7 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, digital shifter routes, XInput-first device selection, hotplug rescan, paused-menu remapping, adjustable FFB, and saved 0–100% steering smoothing pass focused tests | Physical controller, wheel, and FFB acceptance across hardware remains open |
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload on a tested Legend flow | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
-| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. The v2440 live course/result run held 119.7–120.3 FPS with distinct intermediate motion; v2441 reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
+| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2441 2560x1080 Akagi run held 120.0 FPS minimum/average with 120 generated samples minimum and zero moving-race repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
 | Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. One sustained v2440 live Direct run completed exit code 0 and removed its session marker | Repeated live close/restart stress across more GPUs/drivers remains open |
 | Distribution | A BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs and performs verification/extraction locally | Clean-machine coverage is limited and the release remains unfinished |
 
@@ -40,6 +40,12 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 - Tsuchisaka dry/night Bunta likewise loaded `k_tu2`, its forward condition
   geometry, night/no-rain environment, and the Bunta rival package; it advanced
   6.302 m and exited cooperatively with 0.
+- Four fresh v2441 Direct-Vulkan processes covered Myogi, Akina, and Akagi at
+  640x480 plus Akagi at 2560x1080. Every steady race interval recorded zero
+  exact fallback presentations and zero faults. The ultrawide run held 120.0
+  FPS minimum/average for both display and Vulkan across 35 complete samples,
+  with at least 120 generated motion phases in every sample. All four processes
+  exited cooperatively with code 0 and removed their Direct-session markers.
 - v2440 native executable SHA-256: `7FB61B45A0137F8FCE4A9A6CD36200B212F7DFDC6717D851739AD9CBB4D798BC` (binary intentionally not published).
 - The complete offline suite passed CPU/Vulkan pixel comparison, topology,
   projection, ELAN lighting, environment mapping, homogeneous near clipping,

--- a/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2441_2026-09-01.md
@@ -79,10 +79,32 @@ checkpoint. No game data, firmware, PIC/CHD input, extracted asset, card save,
 custom music, capture, log, personal path, or generated game translation unit
 is included in this repository update.
 
+## Direct 120 Hz acceptance update
+
+Four fresh current-build Direct-Vulkan processes covered Myogi, Akina, and
+Akagi at 640x480 plus Akagi at the requested 2560x1080 ultrawide target. Each
+used authentic 60 Hz guest/gameplay timing with distinct generated
+presentation phases, one raster thread, Below Normal process priority, and a
+cooperative window close.
+
+| Route | Target | Complete steady samples | Display min / avg | Vulkan min / avg | Generated min | Moving repeats | Faults |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Myogi left/dry/day | 640x480 | 23 | 120.0 / 120.017 | 120.0 / 120.0 | 120 | 0 | 0 |
+| Akina route | 640x480 | 34 | 119.0 / 119.971 | 119.0 / 119.967 | 119 | 0 | 0 |
+| Akagi left/dry/day | 640x480 | 35 | 119.9 / 120.011 | 119.9 / 120.0 | 120 | 0 | 0 |
+| Akagi left/dry/day | 2560x1080 | 35 | 120.0 / 120.0 | 120.0 / 120.0 | 120 | 0 | 0 |
+
+The 2560x1080 run used anisotropic 16x filtering. Its midpoint-plus-authentic
+worker pair averaged about 16.665 ms. Every process exited with code 0, removed
+its direct-session marker, and left no game process behind. The analyzer used
+for this evidence excludes deliberate F1 pauses, the race-loading ramp, TIME
+UP, and result/menu transitions from moving-race statistics; a deterministic
+10-assertion contract protects those boundaries.
+
 ## Current boundary
 
 The public v2415 package remains the cautious playtest download at 60 FPS.
-v2441 improves a measured CPU preparation path, but 120 Hz is still
-experimental, uncapped presentation is unfinished, and exhaustive route,
-controller/wheel, audio, card-error, clean-machine, and cross-driver acceptance
-remains open.
+v2441 now has fresh targeted 120 Hz Direct-Vulkan acceptance at native and
+ultrawide targets in addition to its complete offline suite. Broader
+whole-game, physical-hardware, clean-machine, and cross-driver acceptance is
+still required before replacing the public checkpoint.


### PR DESCRIPTION
## Summary
- record four clean v2441 Direct-Vulkan route sessions
- add exact 2560x1080 Akagi 120 Hz evidence
- clarify steady-race analyzer boundaries

## Safety boundary
Documentation only. No executable, game data, firmware, PIC/CHD input, extracted assets, logs, captures, card data, custom music, personal paths, or generated game translation units are included.