### PR TITLE
Release v2444 audio and card portability checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v2444-audio-card-portability — 2026-09-01
+
+- Persisted managed card selection by filename so the local `card data` slot
+  survives moving or renaming an extracted demo.
+- Added matching launcher repair for older absolute card paths and verified all
+  private/public PowerShell launchers parse without errors.
+- Added a product-shared Windows audio format/endpoint component and a silent
+  endpoint acceptance probe; the probe opens and closes the real output format
+  without writing sound.
+- Published product-shared XInput discovery/normalization and its no-window
+  hardware probe, including the 35% partial-axis remapping contract.
+- Rebuilt all presenter-dependent owners and passed the complete off-screen,
+  input, audio, music, card, ELAN, Vulkan, timing, lifecycle, freshness,
+  translation, and BIOS-free standalone suite.
+- Re-audited and packaged the 14-file Windows x64 public early demo with no
+  game data, BIOS, card saves, custom music, logs, captures, generated guest
+  code, or private paths.
+
 ## v2441-static-topology-cache — 2026-09-01
 
 - Cached immutable connector, fan, point-validity, and UV-readiness summaries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,20 @@ target_compile_features(native_controller_bindings_test PRIVATE cxx_std_17)
 target_include_directories(native_controller_bindings_test PRIVATE src/runtime)
 
 add_test(NAME native_controller_bindings COMMAND native_controller_bindings_test)
+
+if(WIN32)
+    add_executable(native_xinput_hardware_probe
+        tests/native_xinput_hardware_probe.cpp)
+    target_compile_features(native_xinput_hardware_probe PRIVATE cxx_std_17)
+    target_include_directories(native_xinput_hardware_probe PRIVATE src/runtime)
+    add_test(NAME native_xinput_runtime
+        COMMAND native_xinput_hardware_probe --allow-none)
+
+    add_executable(native_audio_endpoint_probe
+        tests/native_audio_endpoint_probe.cpp)
+    target_compile_features(native_audio_endpoint_probe PRIVATE cxx_std_17)
+    target_include_directories(native_audio_endpoint_probe PRIVATE src/runtime)
+    target_link_libraries(native_audio_endpoint_probe PRIVATE winmm)
+    add_test(NAME native_audio_endpoint
+        COMMAND native_audio_endpoint_probe --allow-none)
+endif()

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of *Initial D Arcade Stage 3* (GDS-0033) for modern Windows PCs.
 > not include game data, a BIOS, card saves, custom music, logs, or extracted
 > assets. You must provide your own legally obtained matching game files.
 
-[**Download Public Early Demo v2415 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2415-host-safety)
+[**Download Public Early Demo v2444 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2444-audio-card-portability)
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
@@ -29,8 +29,8 @@ PIC only to verify and locally extract the data required by the recompilation.
 
 ## Quick start
 
-1. Download and extract `Public Early Demo v2415.zip` from the
-   [v2415 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2415-host-safety).
+1. Download and extract `Public Early Demo v2444.zip` from the
+   [v2444 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2444-audio-card-portability).
 2. Place your own matching files in the included `game files` folder:
    - `gds-0033.chd`
    - `317-0384-com.pic`
@@ -42,9 +42,9 @@ Python is not required. Allow roughly 1.3 GB of temporary free space during
 first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 
 Public ZIP SHA-256:
-`8CA9D017EA5BCFE8EB58245D162D89A22D75267BC6D3BABAD76D922E283B2E8E`
+`BEFE5D96AD8467C63E2A767B920AC523447ED42C3C849A3B817E051456E24515`
 
-## Current integration progress (v2442 WIP)
+## Current integration progress (v2444 WIP)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -67,7 +67,8 @@ Public ZIP SHA-256:
   original asset is overwritten.
 - Card creation/selection in the visible `card data` folder. The last selected
   card is loaded on the next start, and changing cards displays an unsaved-data
-  restart warning.
+  restart warning. Managed selections now remain portable when the extracted
+  demo folder is moved or renamed.
 - A self-contained, Python-free setup and integrity checker for user-owned
   inputs.
 - Cooperative renderer shutdown: the program stops new Vulkan presentation,
@@ -122,6 +123,16 @@ Public ZIP SHA-256:
   Vulkan process running. Axis/button capture, lower-travel axis remapping,
   controller menu navigation, music, card, interpolation, lifecycle, link
   freshness, and the no-firmware boundary all passed their focused checks.
+- The v2443 audio checkpoint opened the exact product 44.1 kHz stereo PCM
+  format on the preferred Windows endpoint without emitting sound, and its
+  null-sink cold run produced 7,080,718 post-mix signal frames with zero AICA
+  drops before cooperative exit.
+- The v2444 card-portability checkpoint rebuilt every presenter-dependent
+  owner and passed the complete controller, physical XInput, AICA mailbox/SGC,
+  Windows endpoint, exact custom-music, interpolation, Direct-session, ELAN,
+  card, offscreen Vulkan, timing, lifecycle, translation, freshness, and
+  standalone no-firmware suite. The clean public ZIP contains 14 audited files
+  and no game data, BIOS, cards, music, logs, captures, or private paths.
 - In the preceding v2440 live RX 9070 XT Direct Vulkan run, a
   75,000–127,000-vertex course/race sequence sustained 119.7–120.3 visible
   presents per second, crossed into the result/continue transition, and then
@@ -147,7 +158,7 @@ is complete.
   content and hardware.
 - Unlimited presentation rate is not finished.
 - Every car/course/weather/day/night combination, long campaign permutation,
-  Bunta condition, and error branch has not been exhaustively rerun on v2415.
+  Bunta condition, and error branch has not been exhaustively rerun on v2444.
 - Physical Xbox discovery now has a product-shared hardware acceptance result;
   live axis/button movement, multiple controller models, wheels/force-feedback,
   and audible end-user audio behavior still need broader acceptance.
@@ -163,9 +174,8 @@ failure, and the newest logs. Do not upload game files, extracted assets, card
 data, or copyrighted music.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
-[the v2442 integration checkpoint](docs/CURRENT_CHECKPOINT_V2442_2026-09-01.md)
-for the latest source/runtime facts, [the v2415 checkpoint](docs/CURRENT_CHECKPOINT_V2415_2026-08-31.md)
-for the current public-release facts, and [ROADMAP.md](ROADMAP.md) for the
+[the v2444 integration/public checkpoint](docs/CURRENT_CHECKPOINT_V2444_2026-09-01.md)
+for the latest source/runtime and release facts, and [ROADMAP.md](ROADMAP.md) for the
 ordered acceptance criteria.
 
 ## Repository contents
@@ -189,7 +199,8 @@ Python translator tests:
 python -m unittest discover -s tests -v
 ```
 
-Native ELAN classifier and controller/smoothing tests:
+Native ELAN classifier, controller/smoothing tests, and Windows-only shared
+XInput/audio endpoint probes:
 
 ```bash
 cmake -S . -B build

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2442 WIP
-Public checkpoint: v2415 Windows x64 early-demo prerelease
+Integration checkpoint: v2444 WIP
+Public checkpoint: v2444 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
 
@@ -15,14 +15,32 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | PVR rendering | Native handling exists for observed opaque/translucent lists, fog, modifier volumes, punch alpha, blend modes, texture layouts, autosort, tile clipping, tested HUD placement, and mirrors | Remaining combinations and presentation edge cases need scene-by-scene validation |
 | Course environment maps | Missing logical lookup paths were recovered from two exact user-owned ISO files; rainbow/static maps are corrected | Other courses and weather conditions are not yet audited |
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, digital shifter routes, XInput-first device selection, hotplug rescan, paused-menu remapping, controller-operated F1 navigation, adjustable FFB, and saved 0–100% steering smoothing pass focused tests. A product-shared no-window probe found a real attached Xbox controller through `xinput1_4.dll` | Live physical axis/button movement, multiple controller models, wheels, and FFB acceptance remain open |
-| Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
-| Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload on a tested Legend flow | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
+| Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; the product's 44.1 kHz stereo PCM format opens on the preferred Windows endpoint; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
+| Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload; selected managed cards use a move-safe path under the local `card data` folder | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
 | Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2441 2560x1080 Akagi run held 120.0 FPS minimum/average with 120 generated samples minimum and zero moving-race repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
 | Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. One sustained v2440 live Direct run completed exit code 0 and removed its session marker | Repeated live close/restart stress across more GPUs/drivers remains open |
-| Distribution | A BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs and performs verification/extraction locally | Clean-machine coverage is limited and the release remains unfinished |
+| Distribution | The v2444 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs and performs verification/extraction locally | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
 
+- v2444 native executable SHA-256: `49BEFEBCD2D23D97CF017EDB7F9F4E5E3685E23AA3994CA774EFE333EBCC4C5D`.
+- v2444 public ZIP SHA-256: `BEFE5D96AD8467C63E2A767B920AC523447ED42C3C849A3B817E051456E24515`; audited size is 18,565,999 bytes.
+- The ZIP contains 14 files and zero CHD, PIC, BIOS, extracted game asset,
+  card, custom music, log, capture, generated guest translation, credential,
+  or private filesystem path entries.
+- Managed F1 card paths are persisted by filename when stored in the product's
+  local `card data` folder. All three launcher variants repair old absolute
+  selections after a demo folder move; their PowerShell parsers report zero
+  errors.
+- v2444 passed the complete controller, attached-Xbox, AICA mailbox/SGC,
+  Windows endpoint, exact custom-music, interpolation, Direct-session marker,
+  ELAN/card/offscreen Vulkan, guest timing, policy, translation-integrity,
+  link-freshness, and standalone product suite. The standalone audit found
+  zero firmware callbacks, firmware AOT objects, firmware input contracts, or
+  cached firmware translations.
+- The v2443 180-second null-sink cold run produced 7,080,718 non-silent
+  post-mix frames, peak magnitude 32768, mean absolute magnitude 5125.22, and
+  zero AICA dropped samples before cooperative exit code 0.
 - v2442 native executable SHA-256: `B56F179C53D3238A6BF311F4E351F2AEE674C8E58397776445DC6F11120C046C` (binary intentionally not published).
 - The product and hardware probe now share one XInput runtime loader and state
   normalizer. On the current Windows host the probe loaded `xinput1_4.dll`,
@@ -109,7 +127,7 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 ## Latest WIP truth
 
 The earlier linked-stream/frame-lifecycle and attract-mode-only blockers are no
-longer the active frontier. The v2415 native build advances targeted
+longer the active frontier. The v2444 native build advances targeted
 menu-to-race and result/save paths, presents retained NAOMI 2 scenes
 continuously, and is available as a public early-demo prerelease that prepares
 data from matching user-owned inputs without a BIOS or Python installation.

--- a/docs/CURRENT_CHECKPOINT_V2444_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2444_2026-09-01.md
@@ -1,0 +1,64 @@
+# Current integration and public checkpoint — v2444
+
+Date: 2026-09-01
+
+Scope: product-shared audio/XInput acceptance and portable managed-card paths
+
+Native executable SHA-256: `49BEFEBCD2D23D97CF017EDB7F9F4E5E3685E23AA3994CA774EFE333EBCC4C5D`
+
+Public ZIP SHA-256: `BEFE5D96AD8467C63E2A767B920AC523447ED42C3C849A3B817E051456E24515`
+
+## What changed
+
+- Managed cards selected or created in F1 are persisted by filename under the
+  product-local `card data` folder. Moving or renaming an extracted demo no
+  longer strands the selection behind an absolute path to its old location.
+- All three maintained Windows launchers recognize older absolute settings and
+  repair them to the same named local card when appropriate.
+- XInput runtime loading, slot discovery, state normalization, and cabinet
+  conversion are shared by the product and a public no-window probe. Axis
+  remapping accepts deliberate 35% travel and the F1 menu accepts controller
+  navigation.
+- The product's 44.1 kHz, stereo, signed-PCM16 wave format and endpoint query
+  are shared with a public probe. The probe opens and closes the endpoint
+  without submitting audio.
+
+## Accepted evidence
+
+The complete v2444 suite passed:
+
+- controller normalization, button/axis capture, and steering filtering;
+- a product-shared probe against an attached Xbox controller through
+  `xinput1_4.dll`;
+- AICA mailbox and Flycast-derived SGC behavior;
+- the product-shared Windows audio endpoint and exact custom-track routing;
+- distinct 60-to-120 Hz presenter interpolation and Direct-session marker
+  lifecycle;
+- ELAN/card behavior and off-screen Vulkan on the attached RX 9070 XT;
+- guest timing, card-eject classification, policy checks, source translation
+  integrity, linked-owner freshness, and the standalone no-firmware boundary.
+
+The standalone audit found zero firmware callbacks, firmware AOT objects,
+firmware input contracts, or cached firmware translations. No game window was
+created for this v2444 acceptance run.
+
+A preceding 180-second cold run used the real AICA mix path with a null host
+sink. It produced 7,080,718 non-silent post-mix frames, peak magnitude 32768,
+mean absolute magnitude 5125.22, zero AICA dropped samples, cooperative exit
+code 0, and no remaining process.
+
+## Public package audit
+
+`Public Early Demo v2444.zip` is 18,565,999 bytes and contains 14 files. The
+archive contains no game image, BIOS, security PIC, CHD, extracted asset, card
+save, custom music, log, frame capture, generated guest translation,
+credential, or private filesystem path. It asks the tester to provide matching
+legally obtained game inputs and prepares them locally without Python or a
+NAOMI 2 BIOS.
+
+## Scope note
+
+This remains an early playtest checkpoint. The accepted results are targeted
+engineering evidence; they are not a claim of exhaustive completion across
+every course, car, weather, time-of-day, controller, audio endpoint, GPU, or
+high-refresh path.

--- a/docs/PUBLIC_PACKAGE.md
+++ b/docs/PUBLIC_PACKAGE.md
@@ -4,7 +4,8 @@
 
 - General SH-4 decoding and code-generation source.
 - Selected clean-room native runtime snapshots.
-- Tests that run without game content.
+- Tests that run without game content, including Windows-only product-shared
+  XInput discovery and silent audio-endpoint probes.
 - Original project documentation, hashes, diagrams, and a limited set of progress captures.
 
 ## Intentionally excluded
@@ -15,4 +16,7 @@
 - Generated translation units derived from the game binary.
 - Executables, object files, compiler caches, private absolute paths, credentials, and proprietary SDK material.
 
-This means the public package documents and tests the engineering work but cannot boot the game by itself. That limitation is intentional.
+The Git source package documents and tests the engineering work but cannot boot
+the game by itself. The separate Windows prerelease includes the native runtime
+and local setup tools, but still contains no user-owned game inputs. That
+boundary is intentional.

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -9,9 +9,16 @@ These files are selected from the private integration tree to show the real clea
 - `native_controller_bindings.h` contains provider-neutral controller binding,
   axis normalization, capture, arcade-range conversion, and the v2413
   presentation-rate-independent steering filter.
+- `native_windows_xinput.h` is the product-shared Windows XInput loader,
+  connected-slot discovery path, and state-to-provider normalization used by
+  both the presenter and the public hardware probe.
+- `native_windows_audio_endpoint.h` defines the product's 44.1 kHz stereo PCM
+  output format and its Windows endpoint identity/volume query.
 
 `native_elan_bridge.h` and `native_controller_bindings.h` are compiled by the
-standalone public checks. The decoder/renderer snapshots refer to support
+portable public checks. On Windows, the same check set also builds no-window
+XInput and silent endpoint probes from the product-shared headers. The
+decoder/renderer snapshots refer to support
 headers in the private integration tree and are included for review, not as a
 claim that this repository is a complete runtime.
 

--- a/src/runtime/native_controller_bindings.h
+++ b/src/runtime/native_controller_bindings.h
@@ -90,7 +90,7 @@ inline float controllerBindingStrength(
 inline ControllerCaptureResult detectControllerBinding(
         const ControllerSnapshot& baseline,
         const ControllerSnapshot& current,
-        float axisThreshold = 0.55f) {
+        float axisThreshold = 0.35f) {
     // Buttons win over axes so pressing a face button while a noisy stick is
     // near its threshold always captures the deliberate control.
     for (uint16_t index = 0u; index < current.buttons.size(); ++index) {
@@ -153,4 +153,3 @@ inline uint16_t arcadePedalFromBinding(
 }
 
 }  // namespace idas3input
-

--- a/src/runtime/native_windows_audio_endpoint.h
+++ b/src/runtime/native_windows_audio_endpoint.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <mmsystem.h>
+#include <mmddk.h>
+
+#include <string>
+
+namespace idas3 {
+
+inline WAVEFORMATEX nativeAudioWaveFormat() {
+    WAVEFORMATEX format{};
+    format.wFormatTag = WAVE_FORMAT_PCM;
+    format.nChannels = 2;
+    format.nSamplesPerSec = 44100u;
+    format.wBitsPerSample = 16u;
+    format.nBlockAlign = static_cast<WORD>(
+        format.nChannels * format.wBitsPerSample / 8u);
+    format.nAvgBytesPerSec =
+        format.nSamplesPerSec * format.nBlockAlign;
+    return format;
+}
+
+struct NativeWaveOutEndpointInfo {
+    MMRESULT idResult = MMSYSERR_ERROR;
+    UINT deviceId = WAVE_MAPPER;
+    MMRESULT capabilitiesResult = MMSYSERR_ERROR;
+    std::string name = "UNKNOWN";
+    MMRESULT volumeResult = MMSYSERR_ERROR;
+    unsigned leftVolume = 0u;
+    unsigned rightVolume = 0u;
+    MMRESULT preferredResult = MMSYSERR_ERROR;
+    UINT preferredDeviceId = WAVE_MAPPER;
+    std::string preferredName = "UNKNOWN";
+};
+
+inline NativeWaveOutEndpointInfo nativeWaveOutEndpointInfo(HWAVEOUT device) {
+    NativeWaveOutEndpointInfo info{};
+    info.idResult = waveOutGetID(device, &info.deviceId);
+    WAVEOUTCAPSA capabilities{};
+    info.capabilitiesResult = info.idResult == MMSYSERR_NOERROR
+        ? waveOutGetDevCapsA(info.deviceId, &capabilities,
+            sizeof(capabilities))
+        : info.idResult;
+    if (info.capabilitiesResult == MMSYSERR_NOERROR)
+        info.name = capabilities.szPname;
+    DWORD endpointVolume = 0u;
+    info.volumeResult = waveOutGetVolume(device, &endpointVolume);
+    info.leftVolume = endpointVolume & 0xFFFFu;
+    info.rightVolume = (endpointVolume >> 16u) & 0xFFFFu;
+    DWORD preferredFlags = 0u;
+    info.preferredResult = waveOutMessage(
+        reinterpret_cast<HWAVEOUT>(static_cast<UINT_PTR>(WAVE_MAPPER)),
+        DRVM_MAPPER_PREFERRED_GET,
+        reinterpret_cast<DWORD_PTR>(&info.preferredDeviceId),
+        reinterpret_cast<DWORD_PTR>(&preferredFlags));
+    if (info.preferredResult == MMSYSERR_NOERROR) {
+        WAVEOUTCAPSA preferredCapabilities{};
+        if (waveOutGetDevCapsA(info.preferredDeviceId,
+                &preferredCapabilities, sizeof(preferredCapabilities)) ==
+                MMSYSERR_NOERROR)
+            info.preferredName = preferredCapabilities.szPname;
+    }
+    return info;
+}
+
+}  // namespace idas3
+
+#endif  // _WIN32

--- a/src/runtime/native_windows_xinput.h
+++ b/src/runtime/native_windows_xinput.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <xinput.h>
+
+#include "native_controller_bindings.h"
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace idas3input {
+
+// Runtime loading keeps the public build independent of a particular XInput
+// import library while still preferring the current Windows implementation.
+// The presenter and the no-window hardware acceptance probe deliberately share
+// this class so a probe success proves the product's real discovery path.
+class NativeXInputRuntime {
+public:
+    using GetStateFunction = DWORD (WINAPI*)(DWORD, XINPUT_STATE*);
+
+    NativeXInputRuntime() {
+        char systemDirectory[MAX_PATH]{};
+        const UINT length = GetSystemDirectoryA(
+            systemDirectory, static_cast<UINT>(std::size(systemDirectory)));
+        if (length == 0u || length >= std::size(systemDirectory)) return;
+
+        static constexpr const char* candidates[] = {
+            "xinput1_4.dll", "xinput9_1_0.dll", "xinput1_3.dll"};
+        for (const char* candidate : candidates) {
+            std::string path(systemDirectory, length);
+            path.push_back('\\');
+            path += candidate;
+            module_ = LoadLibraryA(path.c_str());
+            if (!module_) continue;
+            getState_ = reinterpret_cast<GetStateFunction>(
+                GetProcAddress(module_, "XInputGetState"));
+            if (getState_) {
+                moduleName_ = candidate;
+                break;
+            }
+            FreeLibrary(module_);
+            module_ = nullptr;
+        }
+    }
+
+    ~NativeXInputRuntime() {
+        if (module_) FreeLibrary(module_);
+    }
+
+    NativeXInputRuntime(const NativeXInputRuntime&) = delete;
+    NativeXInputRuntime& operator=(const NativeXInputRuntime&) = delete;
+
+    bool available() const { return getState_ != nullptr; }
+    const char* moduleName() const {
+        return moduleName_.empty() ? "none" : moduleName_.c_str();
+    }
+
+    DWORD getState(DWORD user, XINPUT_STATE* state) const {
+        return getState_ ? getState_(user, state) : ERROR_DEVICE_NOT_CONNECTED;
+    }
+
+    std::vector<DWORD> connectedUsers() const {
+        std::vector<DWORD> users;
+        for (DWORD user = 0u; user < XUSER_MAX_COUNT; ++user) {
+            XINPUT_STATE state{};
+            if (getState(user, &state) == ERROR_SUCCESS)
+                users.push_back(user);
+        }
+        return users;
+    }
+
+private:
+    HMODULE module_ = nullptr;
+    GetStateFunction getState_ = nullptr;
+    std::string moduleName_{};
+};
+
+inline ControllerSnapshot nativeXInputSnapshot(const XINPUT_STATE& state) {
+    ControllerSnapshot snapshot{};
+    snapshot.axes[0] = normalizeSignedAxis(
+        state.Gamepad.sThumbLX, XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE);
+    snapshot.axes[1] = normalizeSignedAxis(
+        state.Gamepad.sThumbLY, XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE);
+    snapshot.axes[2] = normalizeSignedAxis(
+        state.Gamepad.sThumbRX, XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE);
+    snapshot.axes[3] = normalizeSignedAxis(
+        state.Gamepad.sThumbRY, XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE);
+    snapshot.axes[4] = normalizeUnsignedAxis(
+        state.Gamepad.bLeftTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD);
+    snapshot.axes[5] = normalizeUnsignedAxis(
+        state.Gamepad.bRightTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD);
+    static constexpr WORD masks[] = {
+        XINPUT_GAMEPAD_A, XINPUT_GAMEPAD_B, XINPUT_GAMEPAD_X,
+        XINPUT_GAMEPAD_Y, XINPUT_GAMEPAD_LEFT_SHOULDER,
+        XINPUT_GAMEPAD_RIGHT_SHOULDER, XINPUT_GAMEPAD_BACK,
+        XINPUT_GAMEPAD_START, XINPUT_GAMEPAD_LEFT_THUMB,
+        XINPUT_GAMEPAD_RIGHT_THUMB, XINPUT_GAMEPAD_DPAD_UP,
+        XINPUT_GAMEPAD_DPAD_DOWN, XINPUT_GAMEPAD_DPAD_LEFT,
+        XINPUT_GAMEPAD_DPAD_RIGHT};
+    for (size_t index = 0u; index < std::size(masks); ++index)
+        snapshot.buttons[index] =
+            (state.Gamepad.wButtons & masks[index]) != 0u ? 1u : 0u;
+    return snapshot;
+}
+
+}  // namespace idas3input
+
+#endif  // _WIN32

--- a/tests/native_audio_endpoint_probe.cpp
+++ b/tests/native_audio_endpoint_probe.cpp
@@ -1,0 +1,61 @@
+#include "native_windows_audio_endpoint.h"
+
+#include <cstdio>
+#include <cstring>
+
+int main(int argc, char** argv) {
+    bool allowNone = false;
+    for (int index = 1; index < argc; ++index) {
+        if (std::strcmp(argv[index], "--allow-none") == 0)
+            allowNone = true;
+    }
+
+    WAVEFORMATEX format = idas3::nativeAudioWaveFormat();
+    HWAVEOUT device = nullptr;
+    const MMRESULT opened = waveOutOpen(
+        &device, WAVE_MAPPER, &format, 0u, 0u, CALLBACK_NULL);
+    std::printf(
+        "[AUDIO-ENDPOINT-PROBE] open_result=%u rate=%lu channels=%u "
+        "bits=%u block_align=%u\n",
+        static_cast<unsigned>(opened),
+        static_cast<unsigned long>(format.nSamplesPerSec),
+        static_cast<unsigned>(format.nChannels),
+        static_cast<unsigned>(format.wBitsPerSample),
+        static_cast<unsigned>(format.nBlockAlign));
+    if (opened != MMSYSERR_NOERROR || !device) {
+        std::fprintf(stderr,
+            "[AUDIO-ENDPOINT-PROBE] result=%s reason=waveout-open\n",
+            allowNone ? "SKIP" : "FAIL");
+        return allowNone ? 0 : 2;
+    }
+
+    const idas3::NativeWaveOutEndpointInfo info =
+        idas3::nativeWaveOutEndpointInfo(device);
+    std::printf(
+        "[AUDIO-ENDPOINT-PROBE] id_result=%u id=%u caps_result=%u "
+        "name='%s' volume_result=%u volume=%u,%u preferred_result=%u "
+        "preferred_id=%u preferred_name='%s'\n",
+        static_cast<unsigned>(info.idResult),
+        static_cast<unsigned>(info.deviceId),
+        static_cast<unsigned>(info.capabilitiesResult),
+        info.name.c_str(),
+        static_cast<unsigned>(info.volumeResult),
+        info.leftVolume, info.rightVolume,
+        static_cast<unsigned>(info.preferredResult),
+        static_cast<unsigned>(info.preferredDeviceId),
+        info.preferredName.c_str());
+    const MMRESULT closed = waveOutClose(device);
+    if (info.idResult != MMSYSERR_NOERROR ||
+        info.capabilitiesResult != MMSYSERR_NOERROR ||
+        closed != MMSYSERR_NOERROR) {
+        std::fprintf(stderr,
+            "[AUDIO-ENDPOINT-PROBE] result=FAIL reason=endpoint-query-or-close "
+            "close_result=%u\n",
+            static_cast<unsigned>(closed));
+        return 3;
+    }
+    std::printf(
+        "[AUDIO-ENDPOINT-PROBE] result=PASS product-shared-format=1 "
+        "sound_written=0\n");
+    return 0;
+}

--- a/tests/native_controller_bindings_test.cpp
+++ b/tests/native_controller_bindings_test.cpp
@@ -61,7 +61,16 @@ int main() {
     assert(captured.binding.kind == ControllerBindingKind::button);
     assert(captured.binding.index == 2u);
 
+    // A deliberate partial stick/wheel movement must be enough to remap an
+    // axis. Requiring more than half travel made the F1 control capture look
+    // unresponsive, especially on large steering wheels.
+    moved = {};
+    moved.axes[0] = 0.40f;
+    captured = detectControllerBinding(baseline, moved);
+    assert(captured.found);
+    assert(captured.binding.kind == ControllerBindingKind::axisPositive);
+    assert(captured.binding.index == 0u);
+
     std::puts("controller binding normalization/capture tests passed");
     return 0;
 }
-

--- a/tests/native_xinput_hardware_probe.cpp
+++ b/tests/native_xinput_hardware_probe.cpp
@@ -1,0 +1,74 @@
+#include "native_windows_xinput.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+int main(int argc, char** argv) {
+    bool allowNone = false;
+    for (int index = 1; index < argc; ++index) {
+        if (std::strcmp(argv[index], "--allow-none") == 0)
+            allowNone = true;
+    }
+
+    idas3input::NativeXInputRuntime runtime;
+    std::printf("[XINPUT-PROBE] runtime=%u dll='%s'\n",
+        runtime.available() ? 1u : 0u, runtime.moduleName());
+    if (!runtime.available()) {
+        std::fprintf(stderr,
+            "[XINPUT-PROBE] result=FAIL reason=xinput-runtime-unavailable\n");
+        return allowNone ? 0 : 2;
+    }
+
+    const std::vector<DWORD> users = runtime.connectedUsers();
+    std::printf("[XINPUT-PROBE] devices=%zu", users.size());
+    for (DWORD user : users)
+        std::printf(" user=%lu", static_cast<unsigned long>(user));
+    std::printf("\n");
+    if (users.empty()) {
+        std::fprintf(stderr,
+            "[XINPUT-PROBE] result=%s reason=no-connected-controller\n",
+            allowNone ? "SKIP" : "FAIL");
+        return allowNone ? 0 : 3;
+    }
+
+    const DWORD selected = users.front();
+    XINPUT_STATE state{};
+    const DWORD status = runtime.getState(selected, &state);
+    if (status != ERROR_SUCCESS) {
+        std::fprintf(stderr,
+            "[XINPUT-PROBE] result=FAIL reason=selected-read status=%lu\n",
+            static_cast<unsigned long>(status));
+        return 4;
+    }
+
+    const idas3input::ControllerSnapshot snapshot =
+        idas3input::nativeXInputSnapshot(state);
+    std::printf(
+        "[XINPUT-PROBE] selected=%lu packet=%lu buttons=0x%04X "
+        "lx=%.3f ly=%.3f rx=%.3f ry=%.3f lt=%.3f rt=%.3f\n",
+        static_cast<unsigned long>(selected),
+        static_cast<unsigned long>(state.dwPacketNumber),
+        static_cast<unsigned>(state.Gamepad.wButtons),
+        snapshot.axes[0], snapshot.axes[1], snapshot.axes[2],
+        snapshot.axes[3], snapshot.axes[4], snapshot.axes[5]);
+
+    const idas3input::ControllerBinding left{
+        idas3input::ControllerBindingKind::axisNegative, 0u};
+    const idas3input::ControllerBinding right{
+        idas3input::ControllerBindingKind::axisPositive, 0u};
+    const idas3input::ControllerBinding accelerator{
+        idas3input::ControllerBindingKind::axisPositive, 5u};
+    const idas3input::ControllerBinding brake{
+        idas3input::ControllerBindingKind::axisPositive, 4u};
+    std::printf(
+        "[XINPUT-PROBE] cabinet steering=%u accelerator=%u brake=%u\n",
+        static_cast<unsigned>(idas3input::arcadeSteeringFromBindings(
+            snapshot, left, right)),
+        static_cast<unsigned>(idas3input::arcadePedalFromBinding(
+            snapshot, accelerator)),
+        static_cast<unsigned>(idas3input::arcadePedalFromBinding(
+            snapshot, brake)));
+    std::printf("[XINPUT-PROBE] result=PASS product-shared-path=1\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- publishes the v2444 audio/card portability checkpoint and public prerelease metadata
- adds product-shared XInput and silent Windows audio endpoint probes to the source-safe checks
- lowers deliberate axis capture to 35% travel and documents portable managed-card selection
- records the audited 14-file public ZIP and BIOS-free standalone boundary

## Validation
- Python SH-4 translator tests: 5/5 passed
- Native CTest suite: 4/4 passed, including attached Xbox discovery and silent endpoint open/close
- Private v2444 complete offline suite passed
- standalone audit: zero firmware callbacks, AOT objects, input contracts, or cached firmware translations
- public archive audit: 14 files, zero forbidden-content entries