### PR TITLE
Document corrected route evidence policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased route-evidence QA — 2026-09-01
+
+- Corrected a private matrix false negative for Time Attack guest paths that
+  load the exact left/right condition mesh but do not emit the optional
+  three-field selector diagnostic.
+- Kept validation fail-closed when a condition mesh is missing or contradicts
+  the requested side, when only part of a selector identity is present, or
+  when a complete identity disagrees with the manifest.
+- Normalized mixed-generation CSV rows before export so newer evidence columns
+  cannot be silently discarded by the first legacy object in the collection.
+- Added a no-launch evidence reanalysis mode which accepts only logs already
+  tied to the exact executable SHA-256.
+- Revalidated eight v2444 Time Attack/Bunta movement routes as schema-4 PASS,
+  with zero fault markers and zero game processes created by the offline
+  schema upgrade.
+
 ## v2445-direct-persistence — 2026-09-01
 
 - Made the F1 Direct/Safe Vulkan presentation choice survive launcher restart.

--- a/STATUS.md
+++ b/STATUS.md
@@ -23,6 +23,18 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 
 ## Strongest accepted evidence
 
+- Eight route results now carry the exact v2444 executable SHA-256 and pass
+  the corrected schema-4 evidence policy: Myogi left/dry/day, Usui
+  right/wet/night, Akagi left/dry/day, Akina right/wet/night, and Bunta on
+  Irohazaka, Happogahara, Shomaru, and Tsuchisaka. Every row proves the
+  expected primary course, exact condition mesh, time/weather assets, real
+  player movement, zero recognized fault markers, and cooperative exit.
+- The route analyzer now treats the exact left/right condition mesh as
+  authoritative when an optional selector diagnostic is absent, but fails
+  closed on missing, partial, or contradictory direction evidence. Its 18
+  focused contracts pass. The six retained same-hash logs were upgraded
+  offline without launching a game process; Akagi and Akina were also rerun
+  fresh and passed.
 - v2445 public ZIP SHA-256: `301741FEF79AC86CF56F85E9BC19E30D6DC4290833AE3CDF55596C4042F0BB0E`; audited size is 18,565,971 bytes.
 - The versioned launcher maps Direct to the optimized native Vulkan swapchain
   path and Safe to the bounded GPU-readback/Win32 path. Both modes passed the
@@ -155,7 +167,10 @@ broad physical-input acceptance, repeated cross-driver shutdown validation,
 whole-game same-build coverage, remaining visual/audio defects, synchronous
 transition latency, broader clean-machine packaging, and eventually uncapped
 presentation that stays independent from guest gameplay timing. The measured
-high-refresh routes do not make 120 Hz a whole-game validated mode.
+high-refresh routes do not make 120 Hz a whole-game validated mode. Eight of
+the 70 retained Time Attack/Bunta route rows now have exact v2444/schema-4
+proof; the remainder still require same-build renewal before the matrix can be
+called current-build complete.
 
 ## Definition of release-ready
 

--- a/docs/CURRENT_CHECKPOINT_V2445_ROUTE_QA_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2445_ROUTE_QA_2026-09-01.md
@@ -1,0 +1,51 @@
+# v2445 route-evidence QA checkpoint — 2026-09-01
+
+This checkpoint changes QA policy and evidence handling only. The distributed
+native executable remains the accepted BIOS-free v2444 binary packaged by the
+v2445 launcher release.
+
+## What was corrected
+
+Two fresh Time Attack probes loaded the intended course, exact condition mesh,
+time/weather assets, and real player motion, then exited cooperatively with no
+fault marker. The matrix nevertheless marked them failed because their guest
+paths did not emit an optional three-field course-selector diagnostic.
+
+The validator now accepts an exact condition mesh as direction proof:
+
+- left requires `_etc_f`;
+- right requires `_etc_r`;
+- a missing or wrong condition mesh fails;
+- a partially emitted selector identity fails;
+- a complete selector identity must agree with the manifest and mesh;
+- absence of the optional identity alone does not fail.
+
+The implementation also normalizes every row to one ordered schema before CSV
+export. This prevents PowerShell from selecting a legacy first-row property
+set and silently dropping newer evidence columns.
+
+## Safety and acceptance
+
+The focused parser/policy suite passes 18 contracts, including both missing-
+identity cases and all fail-closed contradiction cases. An offline reanalysis
+mode can upgrade an existing log only when its row already records the exact
+requested executable SHA-256; it cannot relabel evidence from another build.
+
+Akagi left/dry/day and Akina right/wet/night were rerun fresh on v2444. They
+advanced 8.612 m and 8.083 m respectively, produced no recognized fault, and
+closed normally with exit code 0. Six other exact-build rows were then parsed
+again offline, with the game-process count remaining zero before and after.
+
+Current exact-build/schema-4 coverage is eight accepted routes:
+
+- Time Attack: Myogi left/dry/day, Usui right/wet/night, Akagi left/dry/day,
+  and Akina right/wet/night.
+- Bunta Challenge: Irohazaka, Happogahara, Shomaru, and Tsuchisaka.
+
+## Remaining work
+
+The retained matrix has 70 rows. Sixty-two still need exact-build renewal.
+These are load/condition/movement checks, not claims that every race has been
+driven to a natural finish or that every visual/audio frame is final. Live
+Direct-Vulkan acceptance remains separate from conservative CPU-preview route
+coverage.


### PR DESCRIPTION
## Summary
- records the fail-closed direction-evidence correction
- documents the eight exact-v2444 schema-4 route passes
- keeps public limitations explicit: 62 retained rows still need renewal

## Validation
- private analyzer policy contracts: 18/18 pass
- public Python tests: 10/10 pass
- Akagi and Akina fresh route probes: cooperative exit 0
- offline schema upgrade: zero game processes before/after

No ROM, BIOS, PIC, CHD, game asset, card, music, log, capture, generated guest translation, credential, or private path is included.