### PR TITLE
Correct route direction evidence and document v2446

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,23 @@
 
 ## Unreleased route-evidence QA — 2026-09-01
 
-- Corrected a private matrix false negative for Time Attack guest paths that
-  load the exact left/right condition mesh but do not emit the optional
-  three-field selector diagnostic.
-- Kept validation fail-closed when a condition mesh is missing or contradicts
-  the requested side, when only part of a selector identity is present, or
-  when a complete identity disagrees with the manifest.
+- Corrected the interim route-evidence interpretation after broader course
+  coverage proved `_etc_f` means dry and `_etc_r` means wet/snow, rather than
+  left and right.
+- Extended the developer-only selector snapshot to the segmented `_pol_a.tbl`
+  course format, while leaving ordinary product launches unchanged.
+- Kept direction validation fail-closed when the three independent selector
+  fields are missing, partial, or disagree with the manifest.
 - Normalized mixed-generation CSV rows before export so newer evidence columns
   cannot be silently discarded by the first legacy object in the collection.
 - Added a no-launch evidence reanalysis mode which accepts only logs already
   tied to the exact executable SHA-256.
-- Revalidated eight v2444 Time Attack/Bunta movement routes as schema-4 PASS,
-  with zero fault markers and zero game processes created by the offline
-  schema upgrade.
+- Passed 20 route-policy contracts and the complete v2446 BIOS-free product,
+  controller, audio, card, renderer, timing, lifecycle, freshness, and
+  standalone suites.
+- Revalidated Akina Snow left/snow/night and Happogahara left/dry/night with
+  exact course/condition assets, independent `0,0,0` direction identities,
+  real movement, no recognized faults, and cooperative exit code 0.
 
 ## v2445-direct-persistence — 2026-09-01
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2445 WIP
+Integration checkpoint: v2446 WIP
 Public checkpoint: v2445 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -23,18 +23,23 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 
 ## Strongest accepted evidence
 
-- Eight route results now carry the exact v2444 executable SHA-256 and pass
-  the corrected schema-4 evidence policy: Myogi left/dry/day, Usui
-  right/wet/night, Akagi left/dry/day, Akina right/wet/night, and Bunta on
-  Irohazaka, Happogahara, Shomaru, and Tsuchisaka. Every row proves the
-  expected primary course, exact condition mesh, time/weather assets, real
-  player movement, zero recognized fault markers, and cooperative exit.
-- The route analyzer now treats the exact left/right condition mesh as
-  authoritative when an optional selector diagnostic is absent, but fails
-  closed on missing, partial, or contradictory direction evidence. Its 18
-  focused contracts pass. The six retained same-hash logs were upgraded
-  offline without launching a game process; Akagi and Akina were also rerun
-  fresh and passed.
+- v2446 extends the developer-only course-selector snapshot to segmented
+  primary tables. Its native executable SHA-256 is
+  `BB453D859F3D7DFD505CAC24501E16B7D17DEBC44ED0B2A7D557574923CB58C8`.
+  Product behavior is unchanged unless QA explicitly enables the diagnostic.
+- The corrected evidence policy recognizes `_etc_f` as dry and `_etc_r` as
+  wet/snow; neither token proves direction. Time Attack direction requires
+  three independent guest selector fields matching the manifest. All 20
+  focused contracts pass, including missing, partial, and contradictory
+  fail-closed cases.
+- Akina Snow left/snow/night and Happogahara left/dry/night pass on v2446 with
+  the expected primary course, condition/time/weather assets, independent
+  `0,0,0` direction identity, real player movement, zero recognized fault
+  markers, and cooperative exit code 0.
+- On exact v2444/schema-5 evidence, all eight Bunta routes plus Myogi
+  left/dry/day and Usui right/wet/night pass. Four segmented Time Attack logs
+  remain correctly marked direction-unverified under v2444 instead of being
+  accepted from a condition token alone.
 - v2445 public ZIP SHA-256: `301741FEF79AC86CF56F85E9BC19E30D6DC4290833AE3CDF55596C4042F0BB0E`; audited size is 18,565,971 bytes.
 - The versioned launcher maps Direct to the optimized native Vulkan swapchain
   path and Safe to the bounded GPU-readback/Win32 path. Both modes passed the
@@ -167,10 +172,11 @@ broad physical-input acceptance, repeated cross-driver shutdown validation,
 whole-game same-build coverage, remaining visual/audio defects, synchronous
 transition latency, broader clean-machine packaging, and eventually uncapped
 presentation that stays independent from guest gameplay timing. The measured
-high-refresh routes do not make 120 Hz a whole-game validated mode. Eight of
-the 70 retained Time Attack/Bunta route rows now have exact v2444/schema-4
-proof; the remainder still require same-build renewal before the matrix can be
-called current-build complete.
+high-refresh routes do not make 120 Hz a whole-game validated mode. The
+70-row ledger is currently mixed-build: ten rows have accepted v2444/schema-5
+proof and two segmented Time Attack rows have accepted v2446/schema-5 proof.
+The remainder still require one-build renewal before the matrix can be called
+current-build complete.
 
 ## Definition of release-ready
 

--- a/docs/CURRENT_CHECKPOINT_V2445_ROUTE_QA_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2445_ROUTE_QA_2026-09-01.md
@@ -1,5 +1,9 @@
 # v2445 route-evidence QA checkpoint — 2026-09-01
 
+> Superseded: broader course evidence disproved this checkpoint's interim
+> interpretation of `_etc_f`/`_etc_r`. See
+> [the v2446 correction](CURRENT_CHECKPOINT_V2446_ROUTE_QA_2026-09-01.md).
+
 This checkpoint changes QA policy and evidence handling only. The distributed
 native executable remains the accepted BIOS-free v2444 binary packaged by the
 v2445 launcher release.
@@ -11,7 +15,8 @@ time/weather assets, and real player motion, then exited cooperatively with no
 fault marker. The matrix nevertheless marked them failed because their guest
 paths did not emit an optional three-field course-selector diagnostic.
 
-The validator now accepts an exact condition mesh as direction proof:
+This checkpoint temporarily accepted an exact condition mesh as direction
+proof:
 
 - left requires `_etc_f`;
 - right requires `_etc_r`;
@@ -36,15 +41,14 @@ advanced 8.612 m and 8.083 m respectively, produced no recognized fault, and
 closed normally with exit code 0. Six other exact-build rows were then parsed
 again offline, with the game-process count remaining zero before and after.
 
-Current exact-build/schema-4 coverage is eight accepted routes:
-
-- Time Attack: Myogi left/dry/day, Usui right/wet/night, Akagi left/dry/day,
-  and Akina right/wet/night.
-- Bunta Challenge: Irohazaka, Happogahara, Shomaru, and Tsuchisaka.
+The accepted count in this superseded checkpoint must not be used as current
+direction coverage. The underlying course, condition, movement, fault, and
+cooperative-exit observations remain useful; direction was reclassified under
+the stricter schema-5 policy.
 
 ## Remaining work
 
-The retained matrix has 70 rows. Sixty-two still need exact-build renewal.
+The retained matrix has 70 rows and still needs one-build renewal.
 These are load/condition/movement checks, not claims that every race has been
 driven to a natural finish or that every visual/audio frame is final. Live
 Direct-Vulkan acceptance remains separate from conservative CPU-preview route

--- a/docs/CURRENT_CHECKPOINT_V2446_ROUTE_QA_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2446_ROUTE_QA_2026-09-01.md
@@ -1,0 +1,55 @@
+# v2446 strict route-evidence checkpoint — 2026-09-01
+
+This checkpoint corrects the superseded v2445 route-QA interpretation. It
+changes developer-only diagnostics and private acceptance tooling; the current
+public package remains v2445.
+
+## Evidence meaning
+
+The broader 70-row ledger proves that condition tokens track weather:
+
+- `_etc_f` is the dry condition mesh;
+- `_etc_r` is the wet or snow condition mesh;
+- both tokens occur for both left and right menu positions;
+- primary course suffixes similarly track day/night on affected courses.
+
+Therefore neither the condition mesh nor the primary table can prove road
+direction. Schema 5 accepts Time Attack direction only when three independently
+isolated persistent guest selector fields are all present and equal the
+manifest's Left=0 or Right=1 value. Missing, partial, or contradictory fields
+fail closed.
+
+## Diagnostic repair
+
+The first selector snapshot recognized only a primary path ending in
+`_pol.tbl`. Several courses load segmented `_pol_a.tbl`, `_pol_b.tbl`, and
+`_pol_c.tbl` tables instead, so no direction identity was emitted.
+
+v2446 recognizes the first `_pol_a.tbl` segment as the same primary-course
+boundary. The code remains gated by `IDAS3_DIAG_COURSE_SELECTION`; normal
+product launches do not read or report the private guest selector fields.
+
+## Acceptance
+
+- Native executable SHA-256:
+  `BB453D859F3D7DFD505CAC24501E16B7D17DEBC44ED0B2A7D557574923CB58C8`.
+- All 116 linked objects passed freshness checks; 108 direct source owners
+  were checked with zero stale objects.
+- The standalone audit found zero firmware callbacks, firmware AOT objects,
+  firmware input contracts, or cached firmware translations.
+- The full controller, attached-Xbox, audio endpoint, AICA, custom-music,
+  interpolation, Direct-session, card, ELAN, offscreen Vulkan, guest-timing,
+  lifecycle, and policy suite passed.
+- The route parser/policy suite passed 20 focused contracts.
+- Akina Snow left/snow/night loaded `k_df3`, condition `r`, night/snow assets,
+  and direction identity `0,0,0`; movement reached 7.964 m and exit was 0.
+- Happogahara left/dry/night loaded `s_vh`, condition `f`, night/dry assets,
+  and direction identity `0,0,0`; movement reached 8.218 m and exit was 0.
+
+## Current limits
+
+The 70-row route ledger still mixes executable checkpoints. Exact
+v2444/schema-5 evidence accepts all eight Bunta rows and two Time Attack rows
+whose original diagnostics were complete. Exact v2446/schema-5 evidence now
+accepts two segmented Time Attack rows. Remaining rows require renewal on one
+build before the matrix can be described as current-build complete.


### PR DESCRIPTION
## Correction
Broader route evidence proved the interim v2445-QA interpretation was wrong: _etc_f is dry and _etc_r is wet/snow; neither proves direction. This PR supersedes that wording immediately.

## v2446
- direction requires three independent selector fields
- segmented _pol_a.tbl courses now emit the developer-only snapshot
- product behavior remains unchanged without the QA environment flag
- 20/20 private route-policy contracts passed
- full BIOS-free/offline regression suite passed
- Akina Snow and Happogahara fresh movement probes passed with selector identity 0,0,0 and cooperative exit 0

## Safety
No ROM, BIOS, PIC, CHD, game asset, card, music, log, capture, generated guest translation, credential, or private path is included.