### PR TITLE
Document v2448 honest FPS acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased v2448 honest-FPS checkpoint — 2026-09-01
+
+- Corrected the in-game FPS overlay so `OUT` is sampled from actual swapchain
+  presentations rather than renderer submissions.
+- Made the presentation counters atomic, removing stale cross-thread reads.
+- Counted both fresh authentic endpoints and interpolated midpoints as `NEW`,
+  while excluding exact cadence and overlay re-presents.
+- Updated the 120 Hz analyzer to use race-motion/positive-travel telemetry so
+  distinct animated menu frames cannot be misclassified as racing.
+- Passed 33 lifecycle/renderer policies, 20 route-parser policies, the new
+  12-case analyzer contract, and the complete BIOS-free product suite.
+- Completed a normal visible 2560x1080 Direct-Vulkan Akagi run at 120.0 FPS
+  minimum/average across 21 moving-race samples, 240 distinct frames per
+  two-second sample, zero repeat growth, zero faults, 129.204 m of movement,
+  cooperative exit code 0, and clean Direct-session-marker removal.
+
 ## Unreleased route-evidence QA — 2026-09-01
 
 - Corrected the interim route-evidence interpretation after broader course

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 Public ZIP SHA-256:
 `301741FEF79AC86CF56F85E9BC19E30D6DC4290833AE3CDF55596C4042F0BB0E`
 
-## Current integration progress (v2445 WIP)
+## Current integration progress (v2448 WIP; public demo remains v2445)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -88,6 +88,8 @@ Public ZIP SHA-256:
 - Exact-matched static course/car batches retain their immutable topology
   eligibility summaries, avoiding repeated full-array scans on each 120 Hz
   presentation phase.
+- The FPS overlay now reports actual swapchain output as `OUT` and genuinely
+  distinct authentic/interpolated frames as `NEW`; exact repeats are excluded.
 
 ## Verified progress
 
@@ -138,6 +140,15 @@ Public ZIP SHA-256:
   swapchain path and Safe to the bounded GPU-readback path through one tested
   helper. Direct and Safe no-launch validation both passed, all maintained
   launchers parsed cleanly, and the native v2444 executable was unchanged.
+- Exact v2446/schema-5 evidence now accepts seven Time Attack rows with
+  independent three-field direction identity. Combined with the ten accepted
+  v2444 rows, the retained mixed-build ledger represents all nine course
+  families without treating dry/wet condition meshes as road direction.
+- The v2448 integration build passed the complete BIOS-free product suite.
+  A normal visible 2560x1080 Direct-Vulkan Akagi run then held 120.0 FPS
+  minimum/average for both display and Vulkan across 21 moving-race samples,
+  produced at least 240 distinct frames per two-second bucket, added zero
+  repeats, advanced 129.204 m, and exited cooperatively with no unclean marker.
 - In the preceding v2440 live RX 9070 XT Direct Vulkan run, a
   75,000–127,000-vertex course/race sequence sustained 119.7–120.3 visible
   presents per second, crossed into the result/continue transition, and then
@@ -163,14 +174,15 @@ is complete.
   content and hardware.
 - Unlimited presentation rate is not finished.
 - Every car/course/weather/day/night combination, long campaign permutation,
-  Bunta condition, and error branch has not been exhaustively rerun on v2445.
+  Bunta condition, and error branch has not been exhaustively rerun on one
+  current integration executable.
 - Physical Xbox discovery now has a product-shared hardware acceptance result;
   live axis/button movement, multiple controller models, wheels/force-feedback,
   and audible end-user audio behavior still need broader acceptance.
-- The cooperative shutdown path passes source and offscreen checks, but a full
-  live Vulkan/WSI stress pass remains deliberately pending after earlier host
-  black-screen incidents. Please close the game normally and report the newest
-  logs if a failure occurs.
+- The cooperative shutdown path passes source/offscreen checks and bounded
+  live Direct-Vulkan runs. Repeated stress across more GPUs and drivers is
+  still required after earlier host black-screen incidents. Please close the
+  game normally and report the newest logs if a failure occurs.
 - Clean-machine packaging needs broader community testing.
 
 When reporting a problem, include the mode, course/opponent, direction,
@@ -181,9 +193,9 @@ data, or copyrighted music.
 See [STATUS.md](STATUS.md) for the evidence ledger,
 [the v2445 public checkpoint](docs/CURRENT_CHECKPOINT_V2445_2026-09-01.md)
 for the latest launcher/release facts,
-[the v2444 integration checkpoint](docs/CURRENT_CHECKPOINT_V2444_2026-09-01.md)
-for the current native-runtime acceptance, and [ROADMAP.md](ROADMAP.md) for the
-ordered acceptance criteria.
+[the v2448 integration checkpoint](docs/CURRENT_CHECKPOINT_V2448_FPS_OVERLAY_2026-09-01.md)
+for the current native-runtime acceptance, and [ROADMAP.md](ROADMAP.md) for
+the ordered acceptance criteria.
 
 ## Repository contents
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2446 WIP
+Integration checkpoint: v2448 WIP
 Public checkpoint: v2445 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -17,12 +17,32 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, digital shifter routes, XInput-first device selection, hotplug rescan, paused-menu remapping, controller-operated F1 navigation, adjustable FFB, and saved 0–100% steering smoothing pass focused tests. A product-shared no-window probe found a real attached Xbox controller through `xinput1_4.dll` | Live physical axis/button movement, multiple controller models, wheels, and FFB acceptance remain open |
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; the product's 44.1 kHz stereo PCM format opens on the preferred Windows endpoint; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload; selected managed cards use a move-safe path under the local `card data` folder | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
-| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2441 2560x1080 Akagi run held 120.0 FPS minimum/average with 120 generated samples minimum and zero moving-race repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
+| Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2448 2560x1080 Akagi run held 120.0 FPS minimum/average across 21 moving-race samples, produced 240 distinct frames per two-second sample, and added zero repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
 | Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. One sustained v2440 live Direct run completed exit code 0 and removed its session marker | Repeated live close/restart stress across more GPUs/drivers remains open |
 | Distribution | The v2445 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, and persists the selected Direct/Safe Vulkan path | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
 
+- v2448 distinguishes swapchain output (`OUT`) from genuinely distinct output
+  (`NEW`) in the in-game FPS overlay. Both counters are sampled on the
+  presentation thread and published atomically; authentic 60 Hz endpoints and
+  interpolated midpoints count as distinct, while cadence repeats do not.
+- The v2448 native executable SHA-256 is
+  `AA068705DB38295967802DBEDAFC2E643A83119F763755D97428567C0DE1DC64`.
+  It passed the complete controller, attached-Xbox, audio endpoint, AICA,
+  custom-music, interpolation, Direct-session, card, ELAN, offscreen Vulkan,
+  guest-timing, lifecycle, link-freshness, translation-integrity, and
+  standalone no-firmware suite.
+- A normal visible Direct-Vulkan v2448 run used a 2560x1080 internal render,
+  authentic 60 Hz game timing, and 120 Hz presentation. Across 21 steady
+  moving-race samples, display and Vulkan minimum/average were all 120.0 FPS,
+  each two-second bucket contained at least 240 distinct frames, the repeat
+  counter delta was zero, movement reached 129.204 m, faults were zero, exit
+  code was 0, and the Direct-session marker was removed.
+- The 120 Hz analyzer now anchors current logs to explicit player-motion and
+  positive-travel telemetry instead of mistaking distinct animated menu frames
+  for race activity. Its focused contract passes 12 cases and retains a
+  generated-frame fallback for historical logs without motion telemetry.
 - v2446 extends the developer-only course-selector snapshot to segmented
   primary tables. Its native executable SHA-256 is
   `BB453D859F3D7DFD505CAC24501E16B7D17DEBC44ED0B2A7D557574923CB58C8`.
@@ -32,9 +52,11 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
   three independent guest selector fields matching the manifest. All 20
   focused contracts pass, including missing, partial, and contradictory
   fail-closed cases.
-- Akina Snow left/snow/night and Happogahara left/dry/night pass on v2446 with
-  the expected primary course, condition/time/weather assets, independent
-  `0,0,0` direction identity, real player movement, zero recognized fault
+- Seven Time Attack rows pass on exact v2446/schema-5 evidence: Akagi
+  left/dry/day, Akina right/wet/night, Akina Snow left/snow/night, Happogahara
+  left/dry/night, Irohazaka left/dry/day, Shomaru left/dry/day, and Tsuchisaka
+  left/dry/day. Each has the expected course/condition/time/weather assets,
+  three-field direction identity, real player movement, zero recognized fault
   markers, and cooperative exit code 0.
 - On exact v2444/schema-5 evidence, all eight Bunta routes plus Myogi
   left/dry/day and Usui right/wet/night pass. Four segmented Time Attack logs
@@ -167,16 +189,17 @@ corrected the tested HUD projection, mirror placement, RX-7 geometry/texture
 failures, and renderer lifecycle defects. This does not imply that all graphics
 or gameplay paths are complete.
 
-The current priority frontier is reducing remaining CPU command preparation,
-broad physical-input acceptance, repeated cross-driver shutdown validation,
-whole-game same-build coverage, remaining visual/audio defects, synchronous
-transition latency, broader clean-machine packaging, and eventually uncapped
-presentation that stays independent from guest gameplay timing. The measured
-high-refresh routes do not make 120 Hz a whole-game validated mode. The
-70-row ledger is currently mixed-build: ten rows have accepted v2444/schema-5
-proof and two segmented Time Attack rows have accepted v2446/schema-5 proof.
-The remainder still require one-build renewal before the matrix can be called
-current-build complete.
+The current priority frontier is isolating remaining terrain/HUD edge artifacts,
+reducing remaining CPU command preparation, broad physical-input acceptance,
+repeated cross-driver shutdown validation, whole-game same-build coverage,
+remaining visual/audio defects, synchronous transition latency, broader
+clean-machine packaging, and eventually uncapped presentation that stays
+independent from guest gameplay timing. The measured high-refresh routes do
+not make 120 Hz a whole-game validated mode. The 70-row ledger is currently
+mixed-build: ten rows have accepted v2444/schema-5 proof and seven Time Attack
+rows have accepted v2446/schema-5 proof. Together they represent all nine
+course families, but the remainder still require one-build renewal before the
+matrix can be called current-build complete.
 
 ## Definition of release-ready
 

--- a/docs/CURRENT_CHECKPOINT_V2446_ROUTE_QA_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2446_ROUTE_QA_2026-09-01.md
@@ -45,11 +45,22 @@ product launches do not read or report the private guest selector fields.
   and direction identity `0,0,0`; movement reached 7.964 m and exit was 0.
 - Happogahara left/dry/night loaded `s_vh`, condition `f`, night/dry assets,
   and direction identity `0,0,0`; movement reached 8.218 m and exit was 0.
+- Akagi left/dry/day loaded `h_hd`, condition `f`, day/dry assets, and
+  direction identity `0,0,0`; movement reached 8.659 m and exit was 0.
+- Akina right/wet/night loaded `k_df2`, condition `r`, night/rain assets, and
+  direction identity `1,1,1`; movement reached 8.083 m and exit was 0.
+- Irohazaka left/dry/day loaded `s_uh`, condition `f`, day/dry assets, and
+  direction identity `0,0,0`; movement reached 6.959 m and exit was 0.
+- Shomaru left/dry/day loaded `n_sy`, condition `f`, day/dry assets, and
+  direction identity `0,0,0`; movement reached 6.275 m and exit was 0.
+- Tsuchisaka left/dry/day loaded `k_tu`, condition `f`, day/dry assets, and
+  direction identity `0,0,0`; movement reached 7.756 m and exit was 0.
 
 ## Current limits
 
 The 70-row route ledger still mixes executable checkpoints. Exact
 v2444/schema-5 evidence accepts all eight Bunta rows and two Time Attack rows
-whose original diagnostics were complete. Exact v2446/schema-5 evidence now
-accepts two segmented Time Attack rows. Remaining rows require renewal on one
-build before the matrix can be described as current-build complete.
+whose original diagnostics were complete. Exact v2446/schema-5 evidence
+accepts seven Time Attack rows. Together these retained checkpoints represent
+all nine course families, but remaining rows still require renewal on one build
+before the matrix can be described as current-build complete.

--- a/docs/CURRENT_CHECKPOINT_V2448_FPS_OVERLAY_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2448_FPS_OVERLAY_2026-09-01.md
@@ -1,0 +1,61 @@
+# v2448 honest-FPS overlay checkpoint — 2026-09-01
+
+This private integration checkpoint corrects the in-game performance counter
+and validates the exact fast Direct-Vulkan path. The current downloadable
+public package remains v2445.
+
+## Counter repair
+
+The earlier overlay mixed two clocks: renderer submissions updated `OUT`,
+while the presentation worker updated `NEW`. Those values also crossed threads
+through ordinary non-atomic doubles. The overlay could consequently show
+`OUT060 NEW000` while the swapchain telemetry proved 120 Hz output.
+
+v2448 samples both values on the presentation thread and publishes them
+atomically:
+
+- `OUT` counts successful displayed swapchain presentations;
+- `NEW` counts fresh authentic game endpoints and valid interpolated
+  midpoints;
+- exact cadence repeats and overlay-only re-presents do not increment `NEW`.
+
+The interpolation/rendering flag remains separate from the distinct-frame
+accounting flag, so this repair does not change game timing, physics, scene
+generation, or interpolation eligibility.
+
+## Acceptance
+
+- Native executable SHA-256:
+  `AA068705DB38295967802DBEDAFC2E643A83119F763755D97428567C0DE1DC64`.
+- All 116 linked objects passed freshness checks; 108 direct source owners
+  were checked with zero stale objects.
+- The standalone audit found zero firmware callbacks, firmware AOT objects,
+  firmware input contracts, or cached firmware translations.
+- The complete controller, attached-Xbox, audio endpoint, AICA, custom-music,
+  interpolation, Direct-session, card, ELAN, offscreen Vulkan, guest-timing,
+  lifecycle, translation, freshness, and standalone suite passed.
+- Focused checks passed: 33 lifecycle/renderer policies, 20 route-parser
+  policies, and 12 analyzer contracts.
+- A normal visible Direct-Vulkan run used a 2560x1080 internal render,
+  authentic 60 Hz gameplay, 120 Hz presentation, VSync, the main monitor,
+  normal process priority, and no diagnostic GPU readback.
+- Across 21 steady moving-race samples, display and Vulkan minimum/average
+  were all 120.0 FPS. Every two-second sample contained at least 240 distinct
+  frames, the repeat-counter delta was zero, and recognized faults were zero.
+- The Akagi route advanced 129.204 m and closed cooperatively with exit code 0.
+  No game process or unclean Direct-Vulkan session marker remained.
+
+## Analyzer compatibility
+
+Now that authentic menu frames correctly count as distinct output, generated
+activity alone cannot identify the start of a race. Current logs are therefore
+anchored to explicit player-motion telemetry and positive travel. Historical
+logs without that telemetry retain the older generated-frame fallback.
+
+## Current limits
+
+This is strong acceptance for one measured route and host, not whole-game 120
+Hz certification. Same-build renewal of the route matrix, remaining visual
+artifact isolation, physical wheel/controller acceptance, audio listening
+coverage, additional GPU/driver shutdown stress, and clean-machine packaging
+remain open.


### PR DESCRIPTION
## Summary
- document atomic OUT/NEW FPS counter repair and exact distinct-frame semantics
- publish the verified 2560x1080 Direct Vulkan 120 Hz moving-race result
- update strict route evidence from two to seven exact v2446 Time Attack rows
- keep v2445 clearly identified as the current downloadable public demo

## Validation
- 33 lifecycle/renderer policy tests
- 20 route parser contracts
- 12 high-refresh analyzer contracts
- complete BIOS-free controller/audio/card/ELAN/Vulkan/guest suite
- normal visible Akagi run: 120.0 FPS minimum/average, 240 distinct frames per two-second sample, zero steady repeats, zero faults, cooperative exit 0

Documentation-only public update. No game data, firmware, cards, music, captures, logs, generated guest code, executables, or private paths are included.