### PR TITLE
Document v2449 cinematic widescreen fix

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -28,7 +28,7 @@ test.
 
 The complete integration build consumes private, legally owned inputs and generates derived C++ translation units that are not part of this public repository. Publishing a command that appears to produce a game from missing data would be misleading. A future release workflow will accept user-supplied inputs locally and keep them outside version control.
 
-The [v2415 public early demo](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2415-host-safety)
+The [v2445 public early demo](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2445-direct-persistence)
 provides the Windows launcher/runtime separately. It verifies and extracts from
 the user's own matching `gds-0033.chd` and `317-0384-com.pic` on that machine;
 it does not make the omitted generated translation units part of this Git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased v2449 cinematic-mask widescreen checkpoint — 2026-09-01
+
+- Traced the centered-4:3 black bars in the authentic attract sequence to two
+  object-space four-vertex cinematic matte batches rather than HUD sprites or
+  terrain.
+- Added a fail-closed classifier using the exact matte mesh/material signature
+  plus proof of projected native x=0..640 coverage.
+- Expanded only accepted mattes about the output centre, reaching the true
+  2560x1080 edges without stretching HUD or changing Hor+ world projection;
+  native 4:3 placement remains unchanged.
+- Passed two BIOS-free attract captures across scenes 3300..3630, including
+  camera cuts whose focal length changes during the matte animation.
+- Passed the complete controller, real-Xbox, audio, music, card, interpolation,
+  ELAN, Vulkan, timing, lifecycle, translation, freshness, and standalone
+  no-firmware suite with cooperative exit and no stale process/session marker.
+
 ## Unreleased v2448 honest-FPS checkpoint — 2026-09-01
 
 - Corrected the in-game FPS overlay so `OUT` is sampled from actual swapchain

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 Public ZIP SHA-256:
 `301741FEF79AC86CF56F85E9BC19E30D6DC4290833AE3CDF55596C4042F0BB0E`
 
-## Current integration progress (v2448 WIP; public demo remains v2445)
+## Current integration progress (v2449 WIP; public demo remains v2445)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -90,6 +90,10 @@ Public ZIP SHA-256:
   presentation phase.
 - The FPS overlay now reports actual swapchain output as `OUT` and genuinely
   distinct authentic/interpolated frames as `NEW`; exact repeats are excluded.
+- Authored attract-mode cinematic mattes now expand to the real widescreen
+  edges. Recognition requires an exact four-vertex mesh/material signature and
+  proof that the projected quad spans the native 0..640 viewport, so HUD and
+  world geometry retain their existing aspect behavior.
 
 ## Verified progress
 
@@ -149,6 +153,12 @@ Public ZIP SHA-256:
   minimum/average for both display and Vulkan across 21 moving-race samples,
   produced at least 240 distinct frames per two-second bucket, added zero
   repeats, advanced 129.204 m, and exited cooperatively with no unclean marker.
+- The v2449 integration build corrected the centered-4:3 cinematic matte on a
+  2560x1080 BIOS-free attract run. Twelve captured scene points covered both
+  the initial narrow-road matte and later changing-zoom car close-ups; the
+  masks reached both output edges while Hor+ world rendering and unstretched
+  UI remained intact. The final build passed the complete product suite and
+  exited with no process or Direct-session marker left behind.
 - In the preceding v2440 live RX 9070 XT Direct Vulkan run, a
   75,000–127,000-vertex course/race sequence sustained 119.7–120.3 visible
   presents per second, crossed into the result/continue transition, and then
@@ -193,7 +203,7 @@ data, or copyrighted music.
 See [STATUS.md](STATUS.md) for the evidence ledger,
 [the v2445 public checkpoint](docs/CURRENT_CHECKPOINT_V2445_2026-09-01.md)
 for the latest launcher/release facts,
-[the v2448 integration checkpoint](docs/CURRENT_CHECKPOINT_V2448_FPS_OVERLAY_2026-09-01.md)
+[the v2449 integration checkpoint](docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md)
 for the current native-runtime acceptance, and [ROADMAP.md](ROADMAP.md) for
 the ordered acceptance criteria.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## Current integration checkpoint — v2441 static topology cache
+## Current integration checkpoint — v2449 cinematic-mask widescreen
 
 - Direct Vulkan presentation bypasses the Safe path's CPU/GDI display boundary
   when explicitly selected.
@@ -18,15 +18,21 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
 - v2441 retains immutable topology eligibility summaries for exact-matched
   static geometry. In the controlled 16,384-vertex reuse case this reduced
   median topology preparation by 35.9% and complete frame time by 9.6%.
-- The complete offline suite, including direct BGR24/BGRA32 channel validation,
-  remains green. The live 120 Hz and clean-exit result above is from v2440;
-  v2441 still needs broader live acceptance rather than another forced launch.
+- v2448 corrected the in-game `OUT`/`NEW` presentation counters and held 120.0
+  FPS with 240 distinct frames per two-second moving-race sample on the exact
+  accepted Akagi run.
+- v2449 expands only exact authored cinematic mattes that prove native
+  x=0..640 coverage. BIOS-free 2560x1080 attract captures pass fixed and
+  changing camera zoom without stretching HUD or world geometry.
+- The complete offline suite, including physical Xbox discovery, audio,
+  music, card, interpolation, Vulkan, lifecycle, and standalone no-firmware
+  checks, remains green.
 
-Checkpoint result: the newest Direct run is host-clean, the bounded v2441 CPU
-optimization is measured and regression-clean, and broader route/cross-driver
-stress is still required.
+Checkpoint result: the newest Direct performance run and v2449 attract runs are
+host-clean, the cinematic widescreen defect is regression-protected, and
+broader route/cross-driver/visual stress is still required.
 
-## Published checkpoint — v2415 public early demo
+## Published checkpoint — v2445 public early demo
 
 - A Windows x64 package now verifies matching user-owned CHD/PIC inputs,
   extracts required data locally, and launches the BIOS-free static-AOT path
@@ -44,8 +50,9 @@ stress is still required.
   product has no unbounded Vulkan queue-idle, device-idle, or fence wait.
 - The product rejects concurrent instances, Windows QA shutdown is
   cooperative-only, and route-only coverage defaults to no Vulkan WSI.
-- Myogi Time Attack plus Shomaru and Tsuchisaka Bunta passed current-build
-  CPU-only route/movement and clean-shutdown probes.
+- The saved Direct/Safe Vulkan presentation choice now survives launcher
+  restart; the public ZIP was re-audited with no game data, firmware, cards,
+  music, captures, generated guest code, or private paths.
 
 Checkpoint result: suitable for cautious public testing at the default 60 FPS,
 not release-ready.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2448 WIP
+Integration checkpoint: v2449 WIP
 Public checkpoint: v2445 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -12,7 +12,7 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | Native boot/runtime | BIOS-free static translated execution cold-boots and advances tested menu, loading, live-race, result, and save paths; 48/48 route/branch targets load | Remaining long campaign permutations and error branches are not complete |
 | Deterministic replay | N70 accepted 70/70 with `unimplemented=0`, `FPSCR=0`, no fault/watchdog, and cross-machine identical frame hash | Uses private user-owned replay/input state that cannot be published |
 | ELAN 3D path | Submitted links, CH2 DMA, completion interrupts, persistent state, materials, instances, lighting, textures, culling, depth, and retained presentation scenes advance continuously through tested races | Untested cars, courses, weather, and scene combinations still need systematic comparison |
-| PVR rendering | Native handling exists for observed opaque/translucent lists, fog, modifier volumes, punch alpha, blend modes, texture layouts, autosort, tile clipping, tested HUD placement, and mirrors | Remaining combinations and presentation edge cases need scene-by-scene validation |
+| PVR rendering | Native handling exists for observed opaque/translucent lists, fog, modifier volumes, punch alpha, blend modes, texture layouts, autosort, tile clipping, tested HUD placement, mirrors, and exact widescreen expansion of authored attract cinematic mattes | Remaining combinations and presentation edge cases need scene-by-scene validation |
 | Course environment maps | Missing logical lookup paths were recovered from two exact user-owned ISO files; rainbow/static maps are corrected | Other courses and weather conditions are not yet audited |
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, digital shifter routes, XInput-first device selection, hotplug rescan, paused-menu remapping, controller-operated F1 navigation, adjustable FFB, and saved 0–100% steering smoothing pass focused tests. A product-shared no-window probe found a real attached Xbox controller through `xinput1_4.dll` | Live physical axis/button movement, multiple controller models, wheels, and FFB acceptance remain open |
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; the product's 44.1 kHz stereo PCM format opens on the preferred Windows endpoint; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
@@ -23,6 +23,21 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 
 ## Strongest accepted evidence
 
+- v2449 identifies the attract sequence's authored black cinematic mattes by
+  exact four-vertex mesh/material state and then requires projected native
+  x=0..640 coverage before expanding them about the output centre. This keeps
+  the fix out of HUD, cars, roads, and other presentation panels.
+- A BIOS-free 2560x1080 attract acceptance captured twelve points from scene
+  3300 through 3630. The initial and changing-zoom matte families reached both
+  output edges while the Hor+ world and UI placement remained unchanged. The
+  process exited cooperatively with code 0; no game process or Direct-session
+  marker remained.
+- The final v2449 executable SHA-256 is
+  `1B1E1990A588DE804CCB6FF19D0D920F60E3EAC038655EA79D39780E5270F479`.
+  It passed the complete controller, attached-Xbox, audio endpoint, AICA,
+  custom-music, interpolation, Direct-session, card, ELAN, offscreen Vulkan,
+  guest-timing, lifecycle, link-freshness, translation-integrity, and
+  standalone no-firmware suite.
 - v2448 distinguishes swapchain output (`OUT`) from genuinely distinct output
   (`NEW`) in the in-game FPS overlay. Both counters are sampled on the
   presentation thread and published atomically; authentic 60 Hz endpoints and
@@ -179,15 +194,15 @@ menu-to-race and result/save paths, presents retained NAOMI 2 scenes
 continuously, and is available as a public early-demo prerelease that prepares
 data from matching user-owned inputs without a BIOS or Python installation.
 
-The latest visual root cause was external asset preparation: two logical course
-lookup names were absent because their ISO9660 physical names are truncated.
-The null table pointer made the guest compositor read unrelated low-memory bytes
-as selectors. Restoring the two exact files from the user's own dump changed
-the invalid selector record to the expected course record and removed the
-alternating rainbow/static environment maps. Subsequent integration work also
-corrected the tested HUD projection, mirror placement, RX-7 geometry/texture
-failures, and renderer lifecycle defects. This does not imply that all graphics
-or gameplay paths are complete.
+Recent visual work separated two different causes. Missing ISO9660-truncated
+course lookup names were restored from the user's own dump, removing the
+alternating rainbow/static environment maps. A later BIOS-free attract capture
+proved that two authored black cinematic mattes were still fixed to the
+centred 640x480 viewport at 2560x1080. v2449 expands only the exact full-native-
+width matte mesh to the output edges and passed both fixed-zoom and changing-
+zoom captures. Earlier work also corrected tested HUD projection, mirror
+placement, RX-7 geometry/texture failures, and renderer lifecycle defects. This
+does not imply that all graphics or gameplay paths are complete.
 
 The current priority frontier is isolating remaining terrain/HUD edge artifacts,
 reducing remaining CPU command preparation, broad physical-input acceptance,

--- a/docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md
@@ -1,0 +1,61 @@
+# v2449 cinematic-mask widescreen checkpoint — 2026-09-01
+
+This private integration checkpoint fixes a reproducible widescreen defect in
+the game's authentic attract sequence. The downloadable public package remains
+v2445 while v2449 receives broader route and packaging acceptance.
+
+## Root cause
+
+At 2560x1080, the 3D world correctly used Hor+ projection, but the game's black
+cinematic mattes covered only the centered 1440-pixel-wide 4:3 image. World
+geometry remained visible in the new left and right regions during camera cuts.
+
+Draw inventories proved that the mattes were not direct-TA HUD sprites. They
+were pairs of ordinary ELAN object-space quads with four vertices, a solid 8x8
+texture, one exact material/raster state, and projected native coverage from
+x=0 through x=640. A later close-up used the same mesh and material while
+changing its camera focal length, so focal length was not a stable identity.
+
+## Repair boundary
+
+v2449 keeps the correction fail-closed:
+
+- the draw must match the exact captured four-vertex mesh, zero-UV layout, and
+  material/raster state;
+- its CPU-projected bounds must independently prove native x=0..640 coverage
+  and a large cinematic-band height;
+- only then are its x coordinates expanded about the output centre by the
+  active aspect compensation;
+- HUD, cars, course geometry, and smaller presentation panels retain their
+  established paths;
+- at 4:3 the compensation is 1.0, so placement is unchanged.
+
+The two four-point batches intentionally leave GPU object projection for this
+small correction. All high-volume course and car projection remains on the GPU.
+
+## Acceptance
+
+- Final native executable SHA-256:
+  `1B1E1990A588DE804CCB6FF19D0D920F60E3EAC038655EA79D39780E5270F479`.
+- A BIOS-free, muted, BelowNormal-priority 2560x1080 attract run captured twelve
+  scene points from 3300 through 3630. Both the initial narrow-road matte and
+  later changing-zoom car close-ups reached the real left and right edges.
+- Hor+ world rendering remained visible in the intended centre band and the UI
+  remained unstretched.
+- Both bounded runs closed cooperatively with exit code 0. No game process or
+  unclean Direct-Vulkan marker remained.
+- The complete controller, attached-Xbox, Windows audio endpoint, AICA,
+  custom-music, interpolation, Direct-session, card, ELAN, offscreen Vulkan,
+  guest-timing, lifecycle, link-freshness, translation-integrity, and
+  standalone suite passed.
+- The standalone audit found zero firmware callbacks, firmware AOT objects,
+  firmware input contracts, or cached firmware translations.
+
+## Current limits
+
+This accepts one exact attract sequence and its observed zoom variants; it is
+not whole-game visual certification. Remaining cars, courses, modes,
+weather/time combinations, transition overlays, high-refresh visual behavior,
+physical wheels/controllers, audio listening, and cross-driver shutdown stress
+still require systematic same-build coverage. No v2449 binary or game-derived
+capture is published in this source checkpoint.

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -22,11 +22,13 @@ decoder/renderer snapshots refer to support
 headers in the private integration tree and are included for review, not as a
 claim that this repository is a complete runtime.
 
-The private v2217 integration tree has advanced beyond these selected snapshots
+The private v2449 integration tree has advanced beyond these selected snapshots
 with targeted menu-to-race/result/save execution, corrected HUD and mirror
 projection, additional PVR list features, native AICA/Maple/JVS/card tests,
 persistent renderer workers, Vulkan pipeline prewarming, fixed 60 Hz retained
-presentation during guest loads, and asset-lineage validation. These components will be moved into this public tree only when they
+presentation during guest loads, distinct 120 Hz presentation accounting,
+exact authored-cinematic-matte widescreen handling, and asset-lineage
+validation. These components will be moved into this public tree only when they
 can be separated cleanly from generated game code and private captures without
 weakening the legal boundary.
 


### PR DESCRIPTION
## Summary
- document the v2449 BIOS-free cinematic-matte widescreen correction
- record exact fail-closed classification and 2560x1080 attract acceptance
- update README, status, roadmap, building guide, and source-snapshot boundary
- keep the downloadable public demo at v2445 pending broader packaging acceptance

## Validation
- complete private v2449 controller/audio/music/card/interpolation/ELAN/Vulkan/lifecycle/standalone suite passed
- BIOS-free attract captures across scenes 3300..3630 passed with cooperative exit and no stale process/session marker
- python -m unittest discover -s tests -v: 10 passed
- public CMake/CTest: 4 passed

No game data, BIOS, PIC, CHD, extracted assets, cards, music, logs, captures, generated guest translations, credentials, or private paths are included.