### PR TITLE
Add v2449 native and Direct acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   native 4:3 placement remains unchanged.
 - Passed two BIOS-free attract captures across scenes 3300..3630, including
   camera cuts whose focal length changes during the matte animation.
+- Matched six v2448/v2449 640x480 captures byte-for-byte and completed a normal
+  visible 2560x1080 Direct run at 119.5–120.5 FPS after warm-up with no
+  diagnostic readback or recognized fault.
 - Passed the complete controller, real-Xbox, audio, music, card, interpolation,
   ELAN, Vulkan, timing, lifecycle, translation, freshness, and standalone
   no-firmware suite with cooperative exit and no stale process/session marker.

--- a/README.md
+++ b/README.md
@@ -157,8 +157,11 @@ Public ZIP SHA-256:
   2560x1080 BIOS-free attract run. Twelve captured scene points covered both
   the initial narrow-road matte and later changing-zoom car close-ups; the
   masks reached both output edges while Hor+ world rendering and unstretched
-  UI remained intact. The final build passed the complete product suite and
-  exited with no process or Direct-session marker left behind.
+  UI remained intact. Six matched 640x480 scenes are byte-identical to v2448,
+  proving native presentation is unchanged. A normal visible Direct run without
+  capture readback held 119.5–120.5 FPS after warm-up and exited without a
+  fault, process, or Direct-session marker. The final build also passed the
+  complete product suite.
 - In the preceding v2440 live RX 9070 XT Direct Vulkan run, a
   75,000–127,000-vertex course/race sequence sustained 119.7–120.3 visible
   presents per second, crossed into the result/continue transition, and then

--- a/STATUS.md
+++ b/STATUS.md
@@ -32,6 +32,14 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
   output edges while the Hor+ world and UI placement remained unchanged. The
   process exited cooperatively with code 0; no game process or Direct-session
   marker remained.
+- Six matched native-resolution scenes from 3300 through 3600 have identical
+  whole-BMP SHA-256 values between v2448 and v2449, demonstrating byte-for-byte
+  640x480 preservation despite routing the two mask quads through CPU
+  projection.
+- A normal visible 2560x1080 Direct-Vulkan v2449 attract run without diagnostic
+  readback held 119.5–120.5 FPS after warm-up (120.0 Vulkan average). During
+  moving attract scenes, two-second buckets produced approximately 239–241
+  distinct frames; the run logged no recognized faults and closed cleanly.
 - The final v2449 executable SHA-256 is
   `1B1E1990A588DE804CCB6FF19D0D920F60E3EAC038655EA79D39780E5270F479`.
   It passed the complete controller, attached-Xbox, audio endpoint, AICA,

--- a/docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md
@@ -42,7 +42,16 @@ small correction. All high-volume course and car projection remains on the GPU.
   later changing-zoom car close-ups reached the real left and right edges.
 - Hor+ world rendering remained visible in the intended centre band and the UI
   remained unstretched.
-- Both bounded runs closed cooperatively with exit code 0. No game process or
+- A separate native-resolution A/B captured scenes 3300, 3360, 3420, 3480,
+  3540, and 3600 from the unchanged v2448 executable and final v2449. All six
+  complete 640x480 BMP files had matching SHA-256 values, proving byte-exact
+  native presentation across fixed and changing camera zoom.
+- A normal visible Direct-Vulkan run on the main monitor used a 2560x1080
+  internal render with no diagnostic GPU readback. After warm-up, presentation
+  remained between 119.5 and 120.5 FPS with a 120.0 Vulkan average. Moving
+  attract buckets produced approximately 239–241 distinct frames per two
+  seconds; static boot/menu periods correctly contained cadence repeats.
+- All bounded runs closed cooperatively with exit code 0. No game process or
   unclean Direct-Vulkan marker remained.
 - The complete controller, attached-Xbox, Windows audio endpoint, AICA,
   custom-music, interpolation, Direct-session, card, ELAN, offscreen Vulkan,


### PR DESCRIPTION
## Summary
- record byte-exact v2448/v2449 640x480 preservation across six matched attract scenes
- record normal visible 2560x1080 Direct-Vulkan 120 Hz acceptance without diagnostic readback
- clarify that static boot/menu cadence repeats are expected while moving attract output is distinct

## Validation
- six complete matched BMP hashes: 6/6 identical
- Direct Vulkan after warm-up: 119.5-120.5 FPS, 120.0 average, no recognized faults
- clean cooperative exit, zero remaining game processes and session markers
- 10 public Python tests and 4 native CTest targets pass

No private captures, logs, paths, game data, firmware, cards, music, or generated guest code are included.