### PR TITLE
Document v2449 route renewal milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Passed the complete controller, real-Xbox, audio, music, card, interpolation,
   ELAN, Vulkan, timing, lifecycle, translation, freshness, and standalone
   no-firmware suite with cooperative exit and no stale process/session marker.
+- Renewed 26 route checks on the exact final v2449 executable: left and right
+  Time Attack coverage for all nine course families plus all eight Bunta
+  courses. Every check matched its requested state, reached real movement,
+  logged zero recognized faults, and exited cooperatively.
 
 ## Unreleased v2448 honest-FPS checkpoint — 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ Public ZIP SHA-256:
   have produced real movement through normal guest physics/input.
 - All 16 unique Time Attack layouts and all 32 Legend rival profiles have
   separate natural, game-owned result evidence.
-- A 70-row Time Attack/Bunta condition matrix has passing route-load/movement
-  evidence. This is mixed-checkpoint evidence, not yet a complete matrix rerun
-  on one v2415 executable. v2415 separately passed CPU-only same-build probes
-  for Myogi Time Attack plus the Shomaru and Tsuchisaka Bunta routes.
+- The 70-row Time Attack/Bunta condition ledger retains passing route-load and
+  movement evidence. On the exact final v2449 executable, 26 selected rows are
+  now freshly current: a left/right Time Attack pair for each of all nine
+  course families plus all eight Bunta courses. Every selected row matched its
+  requested course, condition, time/weather state, and movement requirements;
+  Time Attack direction was independently proven by three agreeing selector
+  fields. All runs reported zero recognized faults and exited cooperatively.
 - The fixed `k_ez` regression route produced 120 distinct motion samples in
   each of 23 complete two-second race intervals, with no repeated moving-race
   endpoints. A four-course priority matrix measured 119.8–120.0 FPS minimum
@@ -162,6 +165,10 @@ Public ZIP SHA-256:
   capture readback held 119.5–120.5 FPS after warm-up and exited without a
   fault, process, or Direct-session marker. The final build also passed the
   complete product suite.
+- Conservative BIOS-free v2449 route renewal now covers 18 Time Attack rows
+  (left and right on every course family, including Akina Snow) and all eight
+  Bunta courses. These 26 current-build checks reached real race movement and
+  shut down cleanly; the remaining 44 condition rows still need v2449 renewal.
 - In the preceding v2440 live RX 9070 XT Direct Vulkan run, a
   75,000–127,000-vertex course/race sequence sustained 119.7–120.3 visible
   presents per second, crossed into the result/continue transition, and then

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,10 +27,15 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
 - The complete offline suite, including physical Xbox discovery, audio,
   music, card, interpolation, Vulkan, lifecycle, and standalone no-firmware
   checks, remains green.
+- Conservative final-v2449 route renewal passes 18 Time Attack checks (both
+  directions across all nine course families) and all eight Bunta courses.
+  All 26 selected rows reached real movement, reported zero recognized faults,
+  and exited cooperatively; 44 condition permutations remain to renew.
 
 Checkpoint result: the newest Direct performance run and v2449 attract runs are
-host-clean, the cinematic widescreen defect is regression-protected, and
-broader route/cross-driver/visual stress is still required.
+host-clean, the cinematic widescreen defect is regression-protected, and every
+course family plus every Bunta course now has current-build movement proof.
+Broader condition/cross-driver/visual stress is still required.
 
 ## Published checkpoint — v2445 public early demo
 
@@ -128,6 +133,8 @@ validated.
 - Preserve the completed natural-result ledger—48/48 target loads, 32/32 rival
   movement, 16/16 Time Attack layouts, and 32/32 rival profiles—while rerunning
   the broader mode/condition matrix on one current executable.
+- Complete the remaining 44 rows of the 70-row v2449 Time Attack/Bunta
+  condition matrix; 26 selected rows are currently renewed and passing.
 - Eliminate unresolved indirect targets and compatibility-only diagnostics.
 - Add deterministic public tests for every source-safe subsystem.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -75,16 +75,15 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
   three independent guest selector fields matching the manifest. All 20
   focused contracts pass, including missing, partial, and contradictory
   fail-closed cases.
-- Seven Time Attack rows pass on exact v2446/schema-5 evidence: Akagi
-  left/dry/day, Akina right/wet/night, Akina Snow left/snow/night, Happogahara
-  left/dry/night, Irohazaka left/dry/day, Shomaru left/dry/day, and Tsuchisaka
-  left/dry/day. Each has the expected course/condition/time/weather assets,
-  three-field direction identity, real player movement, zero recognized fault
-  markers, and cooperative exit code 0.
-- On exact v2444/schema-5 evidence, all eight Bunta routes plus Myogi
-  left/dry/day and Usui right/wet/night pass. Four segmented Time Attack logs
-  remain correctly marked direction-unverified under v2444 instead of being
-  accepted from a condition token alone.
+- Exact final-v2449/schema-5 evidence now accepts 18 Time Attack rows: one left
+  and one right condition on each of all nine course families, including Akina
+  Snow. Every row has the expected course/condition/time/weather assets, three
+  agreeing direction fields, real player movement, zero recognized faults,
+  and cooperative exit code 0.
+- All eight Bunta routes also pass on the same final v2449 executable. Each
+  loaded its game-fixed night/dry course state, applied 480 AI-driving polls,
+  reached measurable player movement, reported zero recognized faults, and
+  exited cooperatively.
 - v2445 public ZIP SHA-256: `301741FEF79AC86CF56F85E9BC19E30D6DC4290833AE3CDF55596C4042F0BB0E`; audited size is 18,565,971 bytes.
 - The versioned launcher maps Direct to the optimized native Vulkan swapchain
   path and Safe to the bounded GPU-readback/Win32 path. Both modes passed the
@@ -218,11 +217,11 @@ repeated cross-driver shutdown validation, whole-game same-build coverage,
 remaining visual/audio defects, synchronous transition latency, broader
 clean-machine packaging, and eventually uncapped presentation that stays
 independent from guest gameplay timing. The measured high-refresh routes do
-not make 120 Hz a whole-game validated mode. The 70-row ledger is currently
-mixed-build: ten rows have accepted v2444/schema-5 proof and seven Time Attack
-rows have accepted v2446/schema-5 proof. Together they represent all nine
-course families, but the remainder still require one-build renewal before the
-matrix can be called current-build complete.
+not make 120 Hz a whole-game validated mode. The 70-row ledger is still
+mixed-build, but 26 rows are now exact final-v2449 evidence: 18 Time Attack
+checks covering both directions on every course family and all eight Bunta
+routes. The remaining 44 condition permutations require v2449 renewal before
+the matrix can be called current-build complete.
 
 ## Definition of release-ready
 

--- a/docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md
@@ -59,6 +59,15 @@ small correction. All high-volume course and car projection remains on the GPU.
   standalone suite passed.
 - The standalone audit found zero firmware callbacks, firmware AOT objects,
   firmware input contracts, or cached firmware translations.
+- Conservative BIOS-free route renewal on this exact executable passed 18
+  Time Attack checks: one left and one right condition on each of all nine
+  course families, including Akina Snow. Each had the expected course,
+  condition, time/weather state, three-field direction identity, real player
+  movement, zero recognized faults, and cooperative exit code 0.
+- All eight Bunta courses passed on the same executable with the expected
+  game-fixed night/dry state, 480 AI-driving polls per route, real movement,
+  zero recognized faults, and cooperative exit code 0. No live Vulkan WSI was
+  opened for these low-priority CPU-preview route checks.
 
 ## Current limits
 
@@ -66,5 +75,7 @@ This accepts one exact attract sequence and its observed zoom variants; it is
 not whole-game visual certification. Remaining cars, courses, modes,
 weather/time combinations, transition overlays, high-refresh visual behavior,
 physical wheels/controllers, audio listening, and cross-driver shutdown stress
-still require systematic same-build coverage. No v2449 binary or game-derived
-capture is published in this source checkpoint.
+still require systematic same-build coverage. The current-build condition
+ledger is 26/70; the remaining 44 permutations are retained as mixed-build
+evidence until renewed on v2449. No v2449 binary or game-derived capture is
+published in this source checkpoint.


### PR DESCRIPTION
## Summary
- document 18 exact-v2449 Time Attack route checks covering both directions on all nine course families
- document all eight exact-v2449 Bunta route checks
- keep the remaining 44 condition permutations and public v2445 package explicitly open

## Validation
- python -m unittest discover -s tests -v (10/10)
- ctest --test-dir build_ci_v2441 -C Release --output-on-failure (2/2)
- git diff --check
- private-path/game-input diff audit