### PR TITLE
Document complete v2449 route matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@
 - Passed the complete controller, real-Xbox, audio, music, card, interpolation,
   ELAN, Vulkan, timing, lifecycle, translation, freshness, and standalone
   no-firmware suite with cooperative exit and no stale process/session marker.
-- Renewed 26 route checks on the exact final v2449 executable: left and right
-  Time Attack coverage for all nine course families plus all eight Bunta
-  courses. Every check matched its requested state, reached real movement,
-  logged zero recognized faults, and exited cooperatively.
+- Renewed the complete 70-row route matrix on the exact final v2449
+  executable: all 62 defined Time Attack direction/weather/time rows and all
+  eight Bunta courses. Every check matched its requested state, reached real
+  movement, logged zero recognized faults, and exited cooperatively; strict
+  no-launch reanalysis returned 70 passes, zero failures, and zero missing.
 
 ## Unreleased v2448 honest-FPS checkpoint — 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,12 @@ Public ZIP SHA-256:
   have produced real movement through normal guest physics/input.
 - All 16 unique Time Attack layouts and all 32 Legend rival profiles have
   separate natural, game-owned result evidence.
-- The 70-row Time Attack/Bunta condition ledger retains passing route-load and
-  movement evidence. On the exact final v2449 executable, 26 selected rows are
-  now freshly current: a left/right Time Attack pair for each of all nine
-  course families plus all eight Bunta courses. Every selected row matched its
-  requested course, condition, time/weather state, and movement requirements;
-  Time Attack direction was independently proven by three agreeing selector
-  fields. All runs reported zero recognized faults and exited cooperatively.
+- The complete 70-row Time Attack/Bunta condition matrix now passes on the
+  exact final v2449 executable: 62 Time Attack direction/weather/time rows and
+  all eight Bunta courses. Every row matched its requested course, condition,
+  state, and movement requirements; Time Attack direction was independently
+  proven by three agreeing selector fields. All runs reported zero recognized
+  faults and exited cooperatively.
 - The fixed `k_ez` regression route produced 120 distinct motion samples in
   each of 23 complete two-second race intervals, with no repeated moving-race
   endpoints. A four-course priority matrix measured 119.8–120.0 FPS minimum
@@ -147,10 +146,10 @@ Public ZIP SHA-256:
   swapchain path and Safe to the bounded GPU-readback path through one tested
   helper. Direct and Safe no-launch validation both passed, all maintained
   launchers parsed cleanly, and the native v2444 executable was unchanged.
-- Exact v2446/schema-5 evidence now accepts seven Time Attack rows with
-  independent three-field direction identity. Combined with the ten accepted
-  v2444 rows, the retained mixed-build ledger represents all nine course
-  families without treating dry/wet condition meshes as road direction.
+- The earlier v2446/schema-5 checkpoint established independent three-field
+  direction identity and stopped treating dry/wet condition meshes as road
+  direction. The final-v2449 70/70 matrix below supersedes its mixed-build
+  route count while retaining that fail-closed evidence policy.
 - The v2448 integration build passed the complete BIOS-free product suite.
   A normal visible 2560x1080 Direct-Vulkan Akagi run then held 120.0 FPS
   minimum/average for both display and Vulkan across 21 moving-race samples,
@@ -165,10 +164,10 @@ Public ZIP SHA-256:
   capture readback held 119.5–120.5 FPS after warm-up and exited without a
   fault, process, or Direct-session marker. The final build also passed the
   complete product suite.
-- Conservative BIOS-free v2449 route renewal now covers 18 Time Attack rows
-  (left and right on every course family, including Akina Snow) and all eight
-  Bunta courses. These 26 current-build checks reached real race movement and
-  shut down cleanly; the remaining 44 condition rows still need v2449 renewal.
+- Conservative BIOS-free v2449 route renewal now covers the entire defined
+  70-row matrix: 62 Time Attack combinations and all eight Bunta courses. A
+  no-launch strict reanalysis also returned 70 passes, zero failures, and zero
+  missing rows for evidence tied to the final executable SHA-256.
 - In the preceding v2440 live RX 9070 XT Direct Vulkan run, a
   75,000–127,000-vertex course/race sequence sustained 119.7–120.3 visible
   presents per second, crossed into the result/continue transition, and then
@@ -193,9 +192,9 @@ is complete.
   expose jitter, clipping, flicker, or unstable performance on unverified
   content and hardware.
 - Unlimited presentation rate is not finished.
-- Every car/course/weather/day/night combination, long campaign permutation,
-  Bunta condition, and error branch has not been exhaustively rerun on one
-  current integration executable.
+- The defined Time Attack/Bunta route-state matrix is current, but every car,
+  opponent, long campaign/result/persistence permutation, and error branch has
+  not been exhaustively completed on one integration executable.
 - Physical Xbox discovery now has a product-shared hardware acceptance result;
   live axis/button movement, multiple controller models, wheels/force-feedback,
   and audible end-user audio behavior still need broader acceptance.
@@ -214,7 +213,9 @@ See [STATUS.md](STATUS.md) for the evidence ledger,
 [the v2445 public checkpoint](docs/CURRENT_CHECKPOINT_V2445_2026-09-01.md)
 for the latest launcher/release facts,
 [the v2449 integration checkpoint](docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md)
-for the current native-runtime acceptance, and [ROADMAP.md](ROADMAP.md) for
+for the current native-runtime acceptance,
+[the v2449 route-matrix checkpoint](docs/CURRENT_CHECKPOINT_V2449_ROUTE_MATRIX_2026-09-01.md)
+for the complete same-build condition ledger, and [ROADMAP.md](ROADMAP.md) for
 the ordered acceptance criteria.
 
 ## Repository contents

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,15 +27,16 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
 - The complete offline suite, including physical Xbox discovery, audio,
   music, card, interpolation, Vulkan, lifecycle, and standalone no-firmware
   checks, remains green.
-- Conservative final-v2449 route renewal passes 18 Time Attack checks (both
-  directions across all nine course families) and all eight Bunta courses.
-  All 26 selected rows reached real movement, reported zero recognized faults,
-  and exited cooperatively; 44 condition permutations remain to renew.
+- Conservative final-v2449 route renewal passes the complete 70-row matrix:
+  all 62 defined Time Attack direction/weather/time rows and all eight Bunta
+  courses. Every row reached real movement, reported zero recognized faults,
+  and exited cooperatively; strict no-launch reanalysis returned 70/70.
 
 Checkpoint result: the newest Direct performance run and v2449 attract runs are
-host-clean, the cinematic widescreen defect is regression-protected, and every
-course family plus every Bunta course now has current-build movement proof.
-Broader condition/cross-driver/visual stress is still required.
+host-clean, the cinematic widescreen defect is regression-protected, and the
+entire route-state matrix now has current-build movement proof. Full-race,
+cross-driver, car/opponent, campaign, persistence, and visual stress are still
+required.
 
 ## Published checkpoint — v2445 public early demo
 
@@ -133,8 +134,8 @@ validated.
 - Preserve the completed natural-result ledger—48/48 target loads, 32/32 rival
   movement, 16/16 Time Attack layouts, and 32/32 rival profiles—while rerunning
   the broader mode/condition matrix on one current executable.
-- Complete the remaining 44 rows of the 70-row v2449 Time Attack/Bunta
-  condition matrix; 26 selected rows are currently renewed and passing.
+- Preserve the completed 70/70 v2449 Time Attack/Bunta route-state matrix while
+  extending coverage through full races, results, continuation, and save paths.
 - Eliminate unresolved indirect targets and compatibility-only diagnostics.
 - Add deterministic public tests for every source-safe subsystem.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -75,11 +75,12 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
   three independent guest selector fields matching the manifest. All 20
   focused contracts pass, including missing, partial, and contradictory
   fail-closed cases.
-- Exact final-v2449/schema-5 evidence now accepts 18 Time Attack rows: one left
-  and one right condition on each of all nine course families, including Akina
-  Snow. Every row has the expected course/condition/time/weather assets, three
-  agreeing direction fields, real player movement, zero recognized faults,
-  and cooperative exit code 0.
+- Exact final-v2449/schema-5 evidence accepts all 62 defined Time Attack rows
+  across all nine course families, including the full dry/wet, day/night, and
+  left/right combinations exposed by the retained matrix plus both Akina Snow
+  directions. Every row has the expected course/condition/time/weather assets,
+  three agreeing direction fields, real player movement, zero recognized
+  faults, and cooperative exit code 0.
 - All eight Bunta routes also pass on the same final v2449 executable. Each
   loaded its game-fixed night/dry course state, applied 480 AI-driving polls,
   reached measurable player movement, reported zero recognized faults, and
@@ -217,11 +218,12 @@ repeated cross-driver shutdown validation, whole-game same-build coverage,
 remaining visual/audio defects, synchronous transition latency, broader
 clean-machine packaging, and eventually uncapped presentation that stays
 independent from guest gameplay timing. The measured high-refresh routes do
-not make 120 Hz a whole-game validated mode. The 70-row ledger is still
-mixed-build, but 26 rows are now exact final-v2449 evidence: 18 Time Attack
-checks covering both directions on every course family and all eight Bunta
-routes. The remaining 44 condition permutations require v2449 renewal before
-the matrix can be called current-build complete.
+not make 120 Hz a whole-game validated mode. The entire 70-row condition
+ledger is now exact final-v2449/schema-5 evidence: 62 Time Attack rows and all
+eight Bunta routes. The remaining coverage frontier is full race completion,
+results/persistence, cars/opponents, visual and audible correctness, campaign
+branches, hardware breadth, and repeated live-renderer stress rather than
+route-state renewal.
 
 ## Definition of release-ready
 

--- a/docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md
@@ -59,11 +59,11 @@ small correction. All high-volume course and car projection remains on the GPU.
   standalone suite passed.
 - The standalone audit found zero firmware callbacks, firmware AOT objects,
   firmware input contracts, or cached firmware translations.
-- Conservative BIOS-free route renewal on this exact executable passed 18
-  Time Attack checks: one left and one right condition on each of all nine
-  course families, including Akina Snow. Each had the expected course,
-  condition, time/weather state, three-field direction identity, real player
-  movement, zero recognized faults, and cooperative exit code 0.
+- Conservative BIOS-free route renewal on this exact executable passed all 62
+  defined Time Attack checks across all nine course families, including Akina
+  Snow. Each had the expected course, condition, time/weather state,
+  three-field direction identity, real player movement, zero recognized
+  faults, and cooperative exit code 0.
 - All eight Bunta courses passed on the same executable with the expected
   game-fixed night/dry state, 480 AI-driving polls per route, real movement,
   zero recognized faults, and cooperative exit code 0. No live Vulkan WSI was
@@ -75,7 +75,8 @@ This accepts one exact attract sequence and its observed zoom variants; it is
 not whole-game visual certification. Remaining cars, courses, modes,
 weather/time combinations, transition overlays, high-refresh visual behavior,
 physical wheels/controllers, audio listening, and cross-driver shutdown stress
-still require systematic same-build coverage. The current-build condition
-ledger is 26/70; the remaining 44 permutations are retained as mixed-build
-evidence until renewed on v2449. No v2449 binary or game-derived capture is
-published in this source checkpoint.
+still require systematic same-build coverage beyond route entry and initial
+movement. The current-build route-state ledger is 70/70, but this does not
+replace full-race, result, persistence, campaign, visual, audio, hardware, or
+live-renderer acceptance. No v2449 binary or game-derived capture is published
+in this source checkpoint.

--- a/docs/CURRENT_CHECKPOINT_V2449_ROUTE_MATRIX_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2449_ROUTE_MATRIX_2026-09-01.md
@@ -1,0 +1,50 @@
+# v2449 complete route-matrix checkpoint — 2026-09-01
+
+The complete retained Time Attack/Bunta route-state matrix now passes on one
+exact BIOS-free native executable. This closes the earlier mixed-build evidence
+gap without publishing private logs, replay inputs, or game-derived data.
+
+## Exact build boundary
+
+- Native executable SHA-256:
+  `1B1E1990A588DE804CCB6FF19D0D920F60E3EAC038655EA79D39780E5270F479`.
+- Evidence schema: 5 for all rows.
+- Total: 70/70 pass, 0 fail, 0 missing.
+- Modes: 62 Time Attack rows and eight Bunta rows.
+- Course families: Myogi, Usui, Akagi, Akina, Irohazaka, Akina Snow,
+  Happogahara, Shomaru, and Tsuchisaka.
+
+## What each pass proves
+
+Every Time Attack row independently requires:
+
+- the expected primary course asset, including segmented Shomaru and
+  Tsuchisaka geometry;
+- the correct dry or wet/snow condition mesh;
+- the requested day or night state and matching rain/snow activity;
+- three separate guest direction-selector fields that all agree with the
+  requested left or right choice;
+- authentic player-car movement beyond the acceptance threshold;
+- zero recognized runtime fault markers and cooperative exit code 0.
+
+Every Bunta row requires the expected game-fixed course/time/weather state,
+the Bunta driving route to be applied, authentic player-car movement, zero
+recognized runtime faults, and cooperative exit code 0.
+
+The original isolated runs used muted, BelowNormal-priority CPU preview with
+one process at a time, a cooldown between cases, and cooperative-only watchdog
+closure. No live Vulkan WSI surface was opened for this route-state campaign.
+Afterward, a no-launch reanalysis reparsed all retained logs, accepted only
+evidence tied to the exact executable hash above, and again returned 70/70.
+
+## What this does not prove
+
+This checkpoint proves route selection, state identity, race entry, and initial
+real movement. It does not claim that all 70 rows were driven to a natural
+finish, that every car/opponent/campaign branch was exercised, or that every
+visual, audio, controller, card, result, continuation, and save behavior is
+correct. Live Vulkan performance and high-refresh acceptance remain separate
+measured campaigns.
+
+No executable, game files, generated guest translations, logs, replay inputs,
+captures, card data, or custom music are published in this source checkpoint.


### PR DESCRIPTION
## Summary
- document the completed exact-v2449 70/70 route-state matrix
- separate 62 Time Attack rows from all eight Bunta routes
- add a source-safe checkpoint defining the proof boundary and remaining full-race work
- retain the public v2445 package and private evidence exclusions

## Validation
- exact executable SHA-256 matched on all 70 rows
- schema-5 no-launch reanalysis: 70 pass, 0 fail, 0 missing
- Python public tests: 10/10
- native CTest: 2/2
- git diff --check and private-path/content audit