### PR TITLE
Document exact-v2449 rival-result renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   eight Bunta courses. Every check matched its requested state, reached real
   movement, logged zero recognized faults, and exited cooperatively; strict
   no-launch reanalysis returned 70 passes, zero failures, and zero missing.
+- Began exact-v2449 natural-result renewal for the 32 retained Legend/Bunta
+  rival profiles. Sakamoto and Wataru passed first: each target moved before a
+  natural game-owned result, received no requested/applied QA outcome after
+  its target gate armed, held at least 59.6 FPS in the accepted race samples,
+  reported zero recognized errors/runtime faults, and exited cooperatively.
 
 ## Unreleased v2448 honest-FPS checkpoint — 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Public ZIP SHA-256:
 
 - All 48 defined route/branch targets have loaded and all 32 rival profiles
   have produced real movement through normal guest physics/input.
-- All 16 unique Time Attack layouts and all 32 Legend rival profiles have
-  separate natural, game-owned result evidence.
+- All 16 unique Time Attack layouts and all 32 retained rival profiles (30
+  Legend plus two Bunta profiles) have separate natural, game-owned result
+  evidence across the historical accepted ledger.
 - The complete 70-row Time Attack/Bunta condition matrix now passes on the
   exact final v2449 executable: 62 Time Attack direction/weather/time rows and
   all eight Bunta courses. Every row matched its requested course, condition,
@@ -112,6 +113,15 @@ Public ZIP SHA-256:
   Direct Vulkan at 60 Hz. Every route showed authentic movement before the
   result, no forced outcome, zero recognized errors/runtime faults, a 59.8 FPS
   or better Vulkan minimum, and cooperative clean-session shutdown.
+- Exact final-v2449 rival-result renewal is now underway rather than being
+  inferred from that historical mixed-checkpoint ledger. Sakamoto and Wataru
+  both reached positive player travel before a natural, game-owned result;
+  prerequisite opponents alone used the disposable-card QA outcome helper.
+  After each target armed, the log recorded zero requested or applied helper
+  outcomes. Both runs held 59.6 FPS or better race/Vulkan minima, reported zero
+  recognized errors/runtime faults, and shut down cooperatively. This is 2/32
+  profiles renewed on the final executable, not yet a whole-ledger same-build
+  claim.
 - The fixed `k_ez` regression route produced 120 distinct motion samples in
   each of 23 complete two-second race intervals, with no repeated moving-race
   endpoints. A four-course priority matrix measured 119.8–120.0 FPS minimum
@@ -220,8 +230,10 @@ for the latest launcher/release facts,
 [the v2449 integration checkpoint](docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md)
 for the current native-runtime acceptance,
 [the v2449 route-matrix checkpoint](docs/CURRENT_CHECKPOINT_V2449_ROUTE_MATRIX_2026-09-01.md)
-for the complete same-build condition ledger, and [ROADMAP.md](ROADMAP.md) for
-the ordered acceptance criteria.
+for the complete same-build condition ledger,
+[the v2449 rival-result renewal checkpoint](docs/CURRENT_CHECKPOINT_V2449_RIVAL_RENEWAL_2026-09-01.md)
+for the current same-build target-gated ledger, and [ROADMAP.md](ROADMAP.md)
+for the ordered acceptance criteria.
 
 ## Repository contents
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,9 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
   all 62 defined Time Attack direction/weather/time rows and all eight Bunta
   courses. Every row reached real movement, reported zero recognized faults,
   and exited cooperatively; strict no-launch reanalysis returned 70/70.
+- Final-v2449 target-gated rival-result renewal has begun with Sakamoto and
+  Wataru passing naturally. This is 2/32 current-build profiles; the historical
+  32/32 accepted ledger is intentionally not promoted to a same-build claim.
 
 Checkpoint result: the newest Direct performance run and v2449 attract runs are
 host-clean, the cinematic widescreen defect is regression-protected, and the

--- a/STATUS.md
+++ b/STATUS.md
@@ -225,6 +225,14 @@ results/persistence, cars/opponents, visual and audible correctness, campaign
 branches, hardware breadth, and repeated live-renderer stress rather than
 route-state renewal.
 
+Exact final-v2449 full-race renewal has also started for the retained rival
+ledger. Sakamoto and Wataru are the first 2/32 target profiles renewed: both
+moved through ordinary guest physics/input and reached a natural game-owned
+result, with zero target outcome requests after the target gate armed, zero
+recognized errors/runtime faults, 59.6 FPS or better race/Vulkan minima, and
+cooperative clean shutdown. The older accepted 32/32 ledger remains useful
+historical evidence, but it is not being presented as a same-build v2449 pass.
+
 ## Definition of release-ready
 
 The downloadable build is an early playtest, not a finished release. The

--- a/docs/CURRENT_CHECKPOINT_V2449_RIVAL_RENEWAL_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2449_RIVAL_RENEWAL_2026-09-01.md
@@ -1,0 +1,52 @@
+# Current checkpoint — v2449 rival-result renewal
+
+## Scope
+
+This checkpoint renews the retained Legend/Bunta rival ledger on the exact
+final v2449 BIOS-free native executable. It does not upload the executable,
+game data, generated guest translations, disposable cards, captures, or raw
+private logs.
+
+- Executable SHA-256:
+  `1B1E1990A588DE804CCB6FF19D0D920F60E3EAC038655EA79D39780E5270F479`
+- Native guest cadence: 60 Hz
+- Presentation: Direct Vulkan, 640x480, 60 Hz, VSync enabled
+- Safety profile: muted, offscreen/background, BelowNormal process priority,
+  one PVR raster thread, cooperative exact-process shutdown
+- Product boundary: cold BIOS-free start; no firmware handoff or interpreter
+  fallback is used
+
+## Accepted target results
+
+| Target | Completed races | Forced prerequisites | Natural target results | Player travel | Display min/avg | Vulkan min/avg | Errors | Runtime faults |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Sakamoto | 6 | 5 | 1 | 314.508 m | 59.7 / 60.0 FPS | 59.6 / 60.0 FPS | 0 | 0 |
+| Wataru | 7 | 6 | 1 | 243.602 m | 59.6 / 60.0 FPS | 59.7 / 60.0 FPS | 0 | 0 |
+
+The outcome helper advanced only prerequisite races on a disposable QA card.
+For both accepted targets, the log first recorded the natural-target arm gate
+and then recorded zero requested and zero applied helper outcomes after that
+line. The target race therefore had to produce its own game-owned result after
+positive player travel. Each run stopped only after that result, requested the
+native presenter's cooperative close path, exited code 0, and removed its
+Direct-session marker.
+
+## Honest coverage statement
+
+The historical accepted ledger contains natural-result evidence for all 32
+retained rival profiles: 30 Legend profiles and two Bunta profiles. Those runs
+span older accepted checkpoints. The same-build final-v2449 renewal is **2/32**
+at this checkpoint, so this document does not claim that the full rival ledger
+has already been renewed on v2449.
+
+The exact-v2449 Time Attack work is further ahead: all 16 retained layouts have
+already completed naturally on this executable, and the separate route-state
+matrix has passed all 70 defined Time Attack/Bunta condition rows.
+
+## Remaining gate
+
+Renew the other 30 target profiles on this exact executable, strictly recheck
+target-arm/result ordering and metrics, fix any same-build regression found,
+and publish only the aggregate source-safe evidence. Whole-game readiness still
+also requires broader visual/audio/input/persistence acceptance and repeated
+cross-driver shutdown stress.


### PR DESCRIPTION
Publishes source-safe final-v2449 Sakamoto and Wataru natural-result evidence, corrects the 30 Legend plus 2 Bunta profile wording, and keeps the same-build tally honest at 2/32. No binaries, game data, generated guest translations, cards, music, captures, logs, or private paths are included. Local verification: 10 Python tests and 4 native C++ tests passed.