### PR TITLE
Document v2453 exact rival renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased v2453 exact rival-result renewal — 2026-09-01
+
+- Corrected developer-only natural-detour attempt bookkeeping so a retry win
+  cannot be miscounted as a second natural detour.
+- Added bounded, default-off outcome-window and outcome-pause QA controls for
+  deterministic menu-path selection without changing ordinary product input.
+- Suppressed already-generated legacy overlay Start/Accelerator pulses during
+  the bounded QA pause, making the pause effective at the final input merge.
+- Added exact executable SHA-256 and safety-profile metadata to race summaries.
+- Added a strict natural-result verifier that fails closed on weak target
+  evidence, post-arm helper writes, runtime faults, live processes, or a stale
+  Direct-session marker.
+- Added an exact-candidate ledger generator which keeps the newest strict pass
+  per target and does not mix evidence from older executable hashes.
+- Strictly renewed seven natural rival results on exact v2453: Evo 5, Keisuke
+  rematch, Kyoko, Ryosuke rematch, Sakamoto, Sudo rematch, and Wataru. All seven
+  averaged 60.0 FPS for display and Direct Vulkan presentation, produced zero
+  recognized fault signals, and closed cooperatively.
+- Kept the same-build claim honest at 7/32; the broader historical 32/32
+  natural-result ledger remains explicitly mixed-checkpoint evidence.
+
 ## Unreleased v2449 cinematic-mask widescreen checkpoint — 2026-09-01
 
 - Traced the centered-4:3 black bars in the authentic attract sequence to two

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 Public ZIP SHA-256:
 `301741FEF79AC86CF56F85E9BC19E30D6DC4290833AE3CDF55596C4042F0BB0E`
 
-## Current integration progress (v2449 WIP; public demo remains v2445)
+## Current integration progress (v2453 WIP; public demo remains v2445)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -113,15 +113,14 @@ Public ZIP SHA-256:
   Direct Vulkan at 60 Hz. Every route showed authentic movement before the
   result, no forced outcome, zero recognized errors/runtime faults, a 59.8 FPS
   or better Vulkan minimum, and cooperative clean-session shutdown.
-- Exact final-v2449 rival-result renewal is now underway rather than being
-  inferred from that historical mixed-checkpoint ledger. Sakamoto and Wataru
-  both reached positive player travel before a natural, game-owned result;
-  prerequisite opponents alone used the disposable-card QA outcome helper.
-  After each target armed, the log recorded zero requested or applied helper
-  outcomes. Both runs held 59.6 FPS or better race/Vulkan minima, reported zero
-  recognized errors/runtime faults, and shut down cooperatively. This is 2/32
-  profiles renewed on the final executable, not yet a whole-ledger same-build
-  claim.
+- Exact-v2453 rival-result renewal is now tracked separately from the
+  historical mixed-checkpoint ledger. Evo 5, the Keisuke rematch, Kyoko, the
+  Ryosuke rematch, Sakamoto, the Sudo rematch, and Wataru each reached positive
+  player travel before a natural, game-owned result. After each target armed,
+  the log recorded zero requested or applied helper outcomes. All seven strict
+  runs averaged 60.0 FPS for display and Direct Vulkan presentation, reported
+  zero fault signals, and shut down cooperatively. This is 7/32 profiles
+  renewed on the exact v2453 SHA-256, not a whole-ledger same-build claim.
 - The fixed `k_ez` regression route produced 120 distinct motion samples in
   each of 23 complete two-second race intervals, with no repeated moving-race
   endpoints. A four-course priority matrix measured 119.8–120.0 FPS minimum
@@ -232,7 +231,9 @@ for the current native-runtime acceptance,
 [the v2449 route-matrix checkpoint](docs/CURRENT_CHECKPOINT_V2449_ROUTE_MATRIX_2026-09-01.md)
 for the complete same-build condition ledger,
 [the v2449 rival-result renewal checkpoint](docs/CURRENT_CHECKPOINT_V2449_RIVAL_RENEWAL_2026-09-01.md)
-for the current same-build target-gated ledger, and [ROADMAP.md](ROADMAP.md)
+for the earlier target-gated ledger,
+[the v2453 exact rival-result checkpoint](docs/CURRENT_CHECKPOINT_V2453_EXACT_RIVAL_RENEWAL_2026-09-01.md)
+for the current same-SHA strict ledger, and [ROADMAP.md](ROADMAP.md)
 for the ordered acceptance criteria.
 
 ## Repository contents

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## Current integration checkpoint — v2449 cinematic-mask widescreen
+## Current integration checkpoint — v2453 exact rival-result renewal
 
 - Direct Vulkan presentation bypasses the Safe path's CPU/GDI display boundary
   when explicitly selected.
@@ -31,15 +31,16 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
   all 62 defined Time Attack direction/weather/time rows and all eight Bunta
   courses. Every row reached real movement, reported zero recognized faults,
   and exited cooperatively; strict no-launch reanalysis returned 70/70.
-- Final-v2449 target-gated rival-result renewal has begun with Sakamoto and
-  Wataru passing naturally. This is 2/32 current-build profiles; the historical
-  32/32 accepted ledger is intentionally not promoted to a same-build claim.
+- Exact-v2453 target-gated rival-result renewal has seven strict passes: Evo 5,
+  Keisuke rematch, Kyoko, Ryosuke rematch, Sakamoto, Sudo rematch, and Wataru.
+  This is 7/32 current-build profiles; the historical 32/32 accepted ledger is
+  intentionally not promoted to a same-build claim.
 
-Checkpoint result: the newest Direct performance run and v2449 attract runs are
-host-clean, the cinematic widescreen defect is regression-protected, and the
-entire route-state matrix now has current-build movement proof. Full-race,
-cross-driver, car/opponent, campaign, persistence, and visual stress are still
-required.
+Checkpoint result: the newest Direct performance and attract runs are
+host-clean, the cinematic widescreen defect is regression-protected, the
+entire route-state matrix has exact-v2449 movement proof, and seven natural
+rival results now have strict exact-v2453 evidence. Full-race, cross-driver,
+car/opponent, campaign, persistence, and visual stress are still required.
 
 ## Published checkpoint — v2445 public early demo
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2449 WIP
+Integration checkpoint: v2453 WIP
 Public checkpoint: v2445 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
@@ -225,13 +225,15 @@ results/persistence, cars/opponents, visual and audible correctness, campaign
 branches, hardware breadth, and repeated live-renderer stress rather than
 route-state renewal.
 
-Exact final-v2449 full-race renewal has also started for the retained rival
-ledger. Sakamoto and Wataru are the first 2/32 target profiles renewed: both
-moved through ordinary guest physics/input and reached a natural game-owned
-result, with zero target outcome requests after the target gate armed, zero
-recognized errors/runtime faults, 59.6 FPS or better race/Vulkan minima, and
-cooperative clean shutdown. The older accepted 32/32 ledger remains useful
-historical evidence, but it is not being presented as a same-build v2449 pass.
+Exact-v2453 full-race renewal now has 7/32 retained rival profiles: Evo 5,
+Keisuke rematch, Kyoko, Ryosuke rematch, Sakamoto, Sudo rematch, and Wataru.
+Each moved through ordinary guest physics/input and reached a natural
+game-owned result, with zero target outcome requests after the target gate
+armed, zero recognized fault signals, 60.0 FPS average display/Direct Vulkan
+presentation, and cooperative clean shutdown. The exact executable SHA-256 is
+`4297DD4906E5A12CD474BC4496E7CF76F907E17CBBB19F92CD6178A09FB3FBD8`.
+The older accepted 32/32 ledger remains useful historical evidence, but it is
+not being presented as a same-build v2453 pass.
 
 ## Definition of release-ready
 

--- a/docs/CURRENT_CHECKPOINT_V2453_EXACT_RIVAL_RENEWAL_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2453_EXACT_RIVAL_RENEWAL_2026-09-01.md
@@ -1,0 +1,83 @@
+# Current checkpoint — v2453 exact rival-result renewal
+
+## Scope
+
+This checkpoint moves the conservative rival-result renewal to the exact v2453
+BIOS-free native executable. It publishes source-safe verification tooling and
+aggregate evidence only. The executable, game data, generated guest
+translations, disposable cards, captures, and raw private logs remain excluded.
+
+- Executable SHA-256:
+  `4297DD4906E5A12CD474BC4496E7CF76F907E17CBBB19F92CD6178A09FB3FBD8`
+- Native guest cadence: 60 Hz
+- Presentation: Direct Vulkan, 640x480, 60 Hz, VSync enabled
+- Safety profile: muted/background, BelowNormal process priority, one PVR
+  raster thread, one exact process at a time, cooperative presenter shutdown
+- Product boundary: cold BIOS-free static-AOT start; no firmware handoff,
+  SH-4 interpreter, or JIT fallback
+
+The v2450-v2453 development sequence corrected natural-detour attempt
+bookkeeping and added bounded, developer-only selector-window/pause controls.
+Those controls default off. While a QA outcome pause is active, v2453 also
+suppresses already-generated legacy overlay Start/Accelerator pulses so the
+pause is real rather than merely cosmetic. Ordinary product input behavior is
+unchanged when the controls are not explicitly enabled.
+
+## Strict exact-candidate results
+
+Each accepted row meets all of these gates:
+
+- the run summary and live executable match the SHA-256 above;
+- the exact target arms naturally exactly once;
+- the target travels at least 10 m through normal input/physics;
+- `RESULT.bin.nz` loads after the natural arm;
+- no developer outcome request or apply occurs after the arm;
+- Direct Vulkan device initialization and post-arm display/present samples are
+  present;
+- no fatal, exception, crash, access-violation, unimplemented, or parser
+  fail-soft signal occurs;
+- cooperative close leaves zero candidate processes and no Direct-session
+  marker.
+
+| Target | Natural travel | Display min/avg | Vulkan min/avg | Natural RESULT loads | Post-arm developer writes | Fault signals |
+|---|---:|---:|---:|---:|---:|---:|
+| Evo 5 | 289.136 m | 59.8 / 60.0 FPS | 59.8 / 60.0 FPS | 1 | 0 | 0 |
+| Keisuke rematch | 787.215 m | 59.8 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
+| Kyoko | 256.297 m | 59.8 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
+| Ryosuke rematch | 360.507 m | 59.8 / 60.0 FPS | 60.0 / 60.0 FPS | 1 | 0 | 0 |
+| Sakamoto | 314.508 m | 59.9 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
+| Sudo rematch | 888.622 m | 59.8 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
+| Wataru | 243.602 m | 59.9 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
+
+The Keisuke route also exercised natural loss/retry detours for Ryosuke and
+Evo 5 before the finale. The Sudo route proved a selector detent change that
+began only after its fifth prerequisite result. Both then completed naturally
+without a post-arm developer result write.
+
+## Honest coverage statement
+
+The historical accepted ledger still contains natural-result evidence for all
+32 retained rival profiles: 30 Legend profiles and two Bunta profiles. Those
+runs span multiple accepted binaries. The exact-v2453 ledger is **7/32**, not
+32/32. This checkpoint deliberately keeps those two claims separate.
+
+The broad historical coverage ledger also reports 48/48 defined route/branch
+targets, 32/32 rival movement, and natural results for all 32 rival profiles.
+It remains useful regression evidence, but it is not proof that every target
+has been renewed on v2453.
+
+## Published QA tools
+
+- `tools/qa/verify_strict_natural_rival_result.ps1` audits one natural target
+  and fails closed on an executable mismatch, weak result evidence, post-arm
+  helper write, runtime fault, live process, or stale Direct-session marker.
+- `tools/qa/update_exact_candidate_natural_coverage.ps1` evaluates summaries
+  tied to one executable SHA-256 and retains the newest strict pass per target.
+  Failed attempts cannot silently replace a valid pass or inflate the count.
+
+## Remaining gate
+
+Renew the other 25 rival targets on this exact executable, strictly recheck
+target-arm/result ordering and metrics, and fix any same-build regression found.
+Whole-game readiness still requires broader visual, audio, controller/wheel,
+card/error-branch, cross-driver, and repeated close/restart acceptance.

--- a/tools/qa/update_exact_candidate_natural_coverage.ps1
+++ b/tools/qa/update_exact_candidate_natural_coverage.ps1
@@ -1,0 +1,184 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CandidateExe,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha256,
+    [string]$EvidenceRoot = '',
+    [string]$Output = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if (-not $EvidenceRoot) {
+    $EvidenceRoot = Join-Path $projectRoot 'runtime\v2250_lead_day'
+}
+if (-not $Output) {
+    $Output = Join-Path $EvidenceRoot 'exact_candidate_natural_coverage.csv'
+}
+
+$exe = (Resolve-Path -LiteralPath $CandidateExe).Path
+$expectedHash = $ExpectedSha256.ToUpperInvariant()
+$actualHash = (Get-FileHash -LiteralPath $exe -Algorithm SHA256).Hash
+if ($actualHash -ne $expectedHash) {
+    throw "Candidate SHA-256 mismatch: expected $expectedHash, got $actualHash"
+}
+
+$live = @(Get-CimInstance Win32_Process | Where-Object {
+    $_.ExecutablePath -eq $exe
+})
+if ($live.Count) {
+    throw "Refusing to summarize a live candidate: $($live.Count) process(es)"
+}
+$marker = Join-Path (Split-Path -Parent $exe) `
+    'idas3_direct_vulkan_unclean.marker'
+if (Test-Path -LiteralPath $marker) {
+    throw "Refusing to summarize candidate with an unclean marker: $marker"
+}
+
+function Test-ExactNaturalEvidence {
+    param([object]$Summary)
+
+    $failures = [Collections.Generic.List[string]]::new()
+    $target = [string]$Summary.NaturalTargetRival
+    $logPath = [string]$Summary.Log
+    if (-not $target) { $failures.Add('natural target is missing') }
+    if (-not (Test-Path -LiteralPath $logPath -PathType Leaf)) {
+        $failures.Add('log is missing')
+        $lines = @()
+    } else {
+        $lines = @(Get-Content -LiteralPath $logPath)
+    }
+
+    $escapedTarget = [regex]::Escape($target)
+    $armIndices = @()
+    for ($index = 0; $index -lt $lines.Count; ++$index) {
+        if ($lines[$index] -match
+            "\[NATIVE-DEVELOPER-RACE-OUTCOME-NATURAL\].*rival=$escapedTarget(?:\s|$)") {
+            $armIndices += $index
+        }
+    }
+    if ($armIndices.Count -ne 1) {
+        $failures.Add("natural arm count is $($armIndices.Count), expected 1")
+        $postArm = @()
+    } else {
+        $postArm = @($lines[$armIndices[0]..($lines.Count - 1)])
+    }
+
+    $maxTravel = 0.0
+    $displayFps = @()
+    $vulkanFps = @()
+    foreach ($line in $postArm) {
+        if ($line -match 'player_travel=([0-9.]+)') {
+            $value = [double]::Parse(
+                $Matches[1], [Globalization.CultureInfo]::InvariantCulture)
+            $maxTravel = [Math]::Max($maxTravel, $value)
+        }
+        if ($line -match '\[DISPLAY-FPS\] instant=([0-9.]+)') {
+            $displayFps += [double]::Parse(
+                $Matches[1], [Globalization.CultureInfo]::InvariantCulture)
+        }
+        if ($line -match '\[VULKAN-PRESENT-FPS\] instant=([0-9.]+)') {
+            $vulkanFps += [double]::Parse(
+                $Matches[1], [Globalization.CultureInfo]::InvariantCulture)
+        }
+    }
+
+    $resultAssets = @($postArm | Where-Object {
+        $_ -match "\[LOAD2APP\] path='/driveA/sound/pack/RESULT\.bin\.nz'"
+    })
+    $developerWrites = @($postArm | Where-Object {
+        $_ -match '\[NATIVE-DEVELOPER-RACE-OUTCOME\] (?:requested|applied)='
+    })
+    $faults = @($lines | Where-Object {
+        $_ -match '(?i)fatal|exception|crash|access violation' -or
+        $_ -match '\[UNIMPLEMENTED\]|\[NSEQ-PARSER-FAILSOFT\]'
+    })
+
+    if ($maxTravel -lt 10.0) { $failures.Add('natural travel is below 10 m') }
+    if ($resultAssets.Count -eq 0) { $failures.Add('natural RESULT asset is missing') }
+    if ($developerWrites.Count) { $failures.Add('developer writes occurred after arm') }
+    if ($faults.Count) { $failures.Add('runtime fault signals are present') }
+    if (-not ($lines | Where-Object { $_ -match '^\[VULKAN\] device:' } |
+            Select-Object -First 1)) {
+        $failures.Add('Direct Vulkan device evidence is missing')
+    }
+    if (-not $displayFps.Count) { $failures.Add('post-arm display FPS is missing') }
+    if (-not $vulkanFps.Count) { $failures.Add('post-arm Vulkan FPS is missing') }
+    if ([int]$Summary.Errors -ne 0) { $failures.Add('summary errors are nonzero') }
+    if ([int]$Summary.RuntimeFaults -ne 0) {
+        $failures.Add('summary runtime faults are nonzero')
+    }
+    if ([int]$Summary.NaturalResults -lt 1) {
+        $failures.Add('summary natural-result count is zero')
+    }
+    if ([string]$Summary.NativeVulkan -ne '1' -or
+        [string]$Summary.VulkanOffscreen -ne '0') {
+        $failures.Add('run was not Direct Vulkan')
+    }
+
+    $displayStats = $displayFps | Measure-Object -Minimum -Average
+    $vulkanStats = $vulkanFps | Measure-Object -Minimum -Average
+    [pscustomobject]@{
+        TargetRival = $target
+        Status = if ($failures.Count) { 'FAIL' } else { 'PASS' }
+        ExecutableSha256 = $actualHash
+        EvidenceGeneratedAtUtc = $Summary.EvidenceGeneratedAtUtc
+        Route = $Summary.Route
+        MaxTargetTravel = '{0:F3}' -f $maxTravel
+        NaturalResultAssetLoads = $resultAssets.Count
+        DeveloperWritesAfterArm = $developerWrites.Count
+        DisplayFpsMin = if ($displayFps.Count) {
+            '{0:F1}' -f $displayStats.Minimum
+        } else { '' }
+        DisplayFpsAverage = if ($displayFps.Count) {
+            '{0:F1}' -f $displayStats.Average
+        } else { '' }
+        VulkanFpsMin = if ($vulkanFps.Count) {
+            '{0:F1}' -f $vulkanStats.Minimum
+        } else { '' }
+        VulkanFpsAverage = if ($vulkanFps.Count) {
+            '{0:F1}' -f $vulkanStats.Average
+        } else { '' }
+        RuntimeFaultSignals = $faults.Count
+        Log = $logPath
+        Failures = $failures -join '; '
+    }
+}
+
+$evaluated = @(Get-ChildItem -LiteralPath $EvidenceRoot -File `
+    -Filter 'ai_profile_summary_*.csv' | ForEach-Object {
+        foreach ($summary in Import-Csv -LiteralPath $_.FullName) {
+            if ($summary.ExecutableSha256 -eq $expectedHash -and
+                $summary.NaturalTargetRival) {
+                Test-ExactNaturalEvidence -Summary $summary
+            }
+        }
+    })
+
+# Keep the newest strict PASS for each target. If a target has no passing run,
+# retain its newest failed attempt so the ledger exposes the gap.
+$rows = @($evaluated | Group-Object TargetRival | ForEach-Object {
+    $passes = @($_.Group | Where-Object Status -eq 'PASS' |
+        Sort-Object EvidenceGeneratedAtUtc -Descending)
+    if ($passes.Count) {
+        $passes[0]
+    } else {
+        $_.Group | Sort-Object EvidenceGeneratedAtUtc -Descending |
+            Select-Object -First 1
+    }
+} | Sort-Object TargetRival)
+
+$rows | Export-Csv -LiteralPath $Output -NoTypeInformation
+$passCount = @($rows | Where-Object Status -eq 'PASS').Count
+$failCount = @($rows | Where-Object Status -eq 'FAIL').Count
+
+[pscustomobject]@{
+    Candidate = $exe
+    ExecutableSha256 = $actualHash
+    ExactNaturalTargetsPassed = $passCount
+    ExactNaturalTargetsFailed = $failCount
+    RivalTargetTotal = 32
+    Output = (Resolve-Path -LiteralPath $Output).Path
+}
+
+if ($failCount) { exit 1 }

--- a/tools/qa/verify_strict_natural_rival_result.ps1
+++ b/tools/qa/verify_strict_natural_rival_result.ps1
@@ -1,0 +1,143 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Log,
+    [Parameter(Mandatory=$true)]
+    [ValidatePattern('^r_[A-Za-z0-9]+$')]
+    [string]$TargetRival,
+    [Parameter(Mandatory=$true)]
+    [string]$Exe,
+    [Parameter(Mandatory=$true)]
+    [ValidatePattern('^[0-9A-Fa-f]{64}$')]
+    [string]$ExpectedExeSha256,
+    [ValidateRange(0.01, 100000.0)]
+    [double]$MinimumTravel = 10.0
+)
+
+$ErrorActionPreference = 'Stop'
+$resolvedLog = (Resolve-Path -LiteralPath $Log).Path
+$resolvedExe = (Resolve-Path -LiteralPath $Exe).Path
+$actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedExe).Hash
+$lines = @(Get-Content -LiteralPath $resolvedLog)
+$failures = [Collections.Generic.List[string]]::new()
+
+if ($actualHash -ne $ExpectedExeSha256.ToUpperInvariant()) {
+    $failures.Add('executable SHA-256 does not match the requested candidate')
+}
+
+$escapedTarget = [regex]::Escape($TargetRival)
+$armMatches = @()
+for ($index = 0; $index -lt $lines.Count; ++$index) {
+    if ($lines[$index] -match
+        "\[NATIVE-DEVELOPER-RACE-OUTCOME-NATURAL\].*rival=$escapedTarget(?:\s|$)") {
+        $armMatches += $index
+    }
+}
+if ($armMatches.Count -ne 1) {
+    $failures.Add(
+        "expected exactly one natural arm for $TargetRival; found $($armMatches.Count)")
+    $postArm = @()
+} else {
+    $postArm = @($lines[$armMatches[0]..($lines.Count - 1)])
+}
+
+$maxTravel = 0.0
+$displayFps = @()
+$vulkanFps = @()
+foreach ($line in $postArm) {
+    if ($line -match 'player_travel=([0-9.]+)') {
+        $travel = [double]::Parse(
+            $Matches[1], [Globalization.CultureInfo]::InvariantCulture)
+        $maxTravel = [Math]::Max($maxTravel, $travel)
+    }
+    if ($line -match '\[DISPLAY-FPS\] instant=([0-9.]+)') {
+        $displayFps += [double]::Parse(
+            $Matches[1], [Globalization.CultureInfo]::InvariantCulture)
+    }
+    if ($line -match '\[VULKAN-PRESENT-FPS\] instant=([0-9.]+)') {
+        $vulkanFps += [double]::Parse(
+            $Matches[1], [Globalization.CultureInfo]::InvariantCulture)
+    }
+}
+if ($maxTravel -lt $MinimumTravel) {
+    $failures.Add(
+        ('target travel {0:F3} m is below required {1:F3} m' -f
+            $maxTravel, $MinimumTravel))
+}
+
+$resultAssets = @($postArm | Where-Object {
+    $_ -match "\[LOAD2APP\] path='/driveA/sound/pack/RESULT\.bin\.nz'"
+})
+if ($resultAssets.Count -eq 0) {
+    $failures.Add('no genuine RESULT asset load occurred after the natural arm')
+}
+
+$postArmDeveloperWrites = @($postArm | Where-Object {
+    $_ -match '\[NATIVE-DEVELOPER-RACE-OUTCOME\] (?:requested|applied)='
+})
+if ($postArmDeveloperWrites.Count -ne 0) {
+    $failures.Add(
+        "developer outcome writes occurred after arm: $($postArmDeveloperWrites.Count)")
+}
+
+$faults = @($lines | Where-Object {
+    $_ -match '(?i)fatal|exception|crash|access violation' -or
+    $_ -match '\[UNIMPLEMENTED\]|\[NSEQ-PARSER-FAILSOFT\]'
+})
+if ($faults.Count -ne 0) {
+    $failures.Add("runtime fault/error signals found: $($faults.Count)")
+}
+if (-not ($lines | Where-Object { $_ -match '^\[VULKAN\] device:' } |
+        Select-Object -First 1)) {
+    $failures.Add('Direct Vulkan device initialization is missing')
+}
+if ($displayFps.Count -eq 0) {
+    $failures.Add('no display FPS samples after natural arm')
+}
+if ($vulkanFps.Count -eq 0) {
+    $failures.Add('no Vulkan present FPS samples after natural arm')
+}
+
+$processCount = @(Get-CimInstance Win32_Process | Where-Object {
+    $_.ExecutablePath -eq $resolvedExe
+}).Count
+if ($processCount -ne 0) {
+    $failures.Add("candidate still has $processCount live process(es)")
+}
+$marker = Join-Path (Split-Path -Parent $resolvedExe) `
+    'idas3_direct_vulkan_unclean.marker'
+$markerPresent = Test-Path -LiteralPath $marker
+if ($markerPresent) {
+    $failures.Add('Direct Vulkan unclean-session marker is still present')
+}
+
+$displayStats = $displayFps | Measure-Object -Minimum -Average
+$vulkanStats = $vulkanFps | Measure-Object -Minimum -Average
+$result = [pscustomobject]@{
+    Status = if ($failures.Count) { 'FAIL' } else { 'PASS' }
+    TargetRival = $TargetRival
+    Executable = $resolvedExe
+    ExecutableSha256 = $actualHash
+    Log = $resolvedLog
+    NaturalArmCount = $armMatches.Count
+    MaxTargetTravel = '{0:F3}' -f $maxTravel
+    NaturalResultAssetLoads = $resultAssets.Count
+    DeveloperWritesAfterArm = $postArmDeveloperWrites.Count
+    DisplayFpsMin = if ($displayFps.Count) {
+        '{0:F1}' -f $displayStats.Minimum
+    } else { '' }
+    DisplayFpsAverage = if ($displayFps.Count) {
+        '{0:F1}' -f $displayStats.Average
+    } else { '' }
+    VulkanFpsMin = if ($vulkanFps.Count) {
+        '{0:F1}' -f $vulkanStats.Minimum
+    } else { '' }
+    VulkanFpsAverage = if ($vulkanFps.Count) {
+        '{0:F1}' -f $vulkanStats.Average
+    } else { '' }
+    RuntimeFaultSignals = $faults.Count
+    LiveCandidateProcesses = $processCount
+    UncleanMarkerPresent = $markerPresent
+    Failures = $failures -join '; '
+}
+$result | Format-List
+if ($failures.Count) { exit 1 }


### PR DESCRIPTION
## Summary
- publish the strict natural-rival verifier and exact-candidate ledger tool
- document seven exact-v2453 natural target passes at the retained executable SHA-256
- keep historical 32/32 coverage explicitly separate from the 7/32 same-build claim
- refresh README, status, roadmap, and changelog

## Validation
- PowerShell parsing: PASS
- exact-candidate ledger reanalysis: 7 PASS / 0 FAIL
- strict result checks: seven accepted targets, zero post-arm outcome writes/fault signals
- python tests/test_launcher_policy.py: PASS
- python tests/test_sh4_fpu_codegen.py: PASS
- git diff --check: PASS
- private-path/credential scan: PASS

No executable, game data, generated guest code, card, custom music, capture, or raw private log is included.