### PR TITLE
Fix relocated Windows launcher validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,20 @@
   Direct-session marker.
 - Added an exact-candidate ledger generator which keeps the newest strict pass
   per target and does not mix evidence from older executable hashes.
-- Strictly renewed seven natural rival results on exact v2453: Evo 5, Keisuke
-  rematch, Kyoko, Ryosuke rematch, Sakamoto, Sudo rematch, and Wataru. All seven
-  averaged 60.0 FPS for display and Direct Vulkan presentation, produced zero
-  recognized fault signals, and closed cooperatively.
-- Kept the same-build claim honest at 7/32; the broader historical 32/32
+- Strictly renewed nine natural rival results on exact v2453: Evo 5, Evo 6,
+  Keisuke rematch, Kyoko, Ryosuke rematch, Sakamoto, Smiley, Sudo rematch, and
+  Wataru. All nine averaged 60.0 FPS for display and Direct Vulkan
+  presentation, produced zero recognized fault signals, and closed
+  cooperatively.
+- Kept the same-build claim honest at 9/32; the broader historical 32/32
   natural-result ledger remains explicitly mixed-checkpoint evidence.
+- Corrected the portable-card repair path so its diagnostic cannot be captured
+  as a drive name when a build folder moves.
+- Added a content-verified retry before automatic CHD setup, preventing a
+  transient metadata check from falsely reporting a clean extracted build as a
+  corrupt source disc.
+- Added an isolated moved-build regression which exercises the fast-to-full
+  integrity retry without loading game data or starting a game process.
 
 ## Unreleased v2449 cinematic-mask widescreen checkpoint — 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -114,12 +114,13 @@ Public ZIP SHA-256:
   result, no forced outcome, zero recognized errors/runtime faults, a 59.8 FPS
   or better Vulkan minimum, and cooperative clean-session shutdown.
 - Exact-v2453 rival-result renewal is now tracked separately from the
-  historical mixed-checkpoint ledger. Evo 5, the Keisuke rematch, Kyoko, the
-  Ryosuke rematch, Sakamoto, the Sudo rematch, and Wataru each reached positive
-  player travel before a natural, game-owned result. After each target armed,
-  the log recorded zero requested or applied helper outcomes. All seven strict
-  runs averaged 60.0 FPS for display and Direct Vulkan presentation, reported
-  zero fault signals, and shut down cooperatively. This is 7/32 profiles
+  historical mixed-checkpoint ledger. Evo 5, Evo 6, the Keisuke rematch, Kyoko,
+  the Ryosuke rematch, Sakamoto, Smiley, the Sudo rematch, and Wataru each
+  reached positive player travel before a natural, game-owned result. After
+  each target armed, the log recorded zero requested or applied helper
+  outcomes. All nine strict runs averaged 60.0 FPS for display and Direct
+  Vulkan presentation, reported zero fault signals, and shut down
+  cooperatively. This is 9/32 profiles
   renewed on the exact v2453 SHA-256, not a whole-ledger same-build claim.
 - The fixed `k_ez` regression route produced 120 distinct motion samples in
   each of 23 complete two-second race intervals, with no repeated moving-race

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,14 +31,14 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
   all 62 defined Time Attack direction/weather/time rows and all eight Bunta
   courses. Every row reached real movement, reported zero recognized faults,
   and exited cooperatively; strict no-launch reanalysis returned 70/70.
-- Exact-v2453 target-gated rival-result renewal has seven strict passes: Evo 5,
-  Keisuke rematch, Kyoko, Ryosuke rematch, Sakamoto, Sudo rematch, and Wataru.
-  This is 7/32 current-build profiles; the historical 32/32 accepted ledger is
-  intentionally not promoted to a same-build claim.
+- Exact-v2453 target-gated rival-result renewal has nine strict passes: Evo 5,
+  Evo 6, Keisuke rematch, Kyoko, Ryosuke rematch, Sakamoto, Smiley, Sudo
+  rematch, and Wataru. This is 9/32 current-build profiles; the historical
+  32/32 accepted ledger is intentionally not promoted to a same-build claim.
 
 Checkpoint result: the newest Direct performance and attract runs are
 host-clean, the cinematic widescreen defect is regression-protected, the
-entire route-state matrix has exact-v2449 movement proof, and seven natural
+entire route-state matrix has exact-v2449 movement proof, and nine natural
 rival results now have strict exact-v2453 evidence. Full-race, cross-driver,
 car/opponent, campaign, persistence, and visual stress are still required.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -225,8 +225,9 @@ results/persistence, cars/opponents, visual and audible correctness, campaign
 branches, hardware breadth, and repeated live-renderer stress rather than
 route-state renewal.
 
-Exact-v2453 full-race renewal now has 7/32 retained rival profiles: Evo 5,
-Keisuke rematch, Kyoko, Ryosuke rematch, Sakamoto, Sudo rematch, and Wataru.
+Exact-v2453 full-race renewal now has 9/32 retained rival profiles: Evo 5,
+Evo 6, Keisuke rematch, Kyoko, Ryosuke rematch, Sakamoto, Smiley, Sudo rematch,
+and Wataru.
 Each moved through ordinary guest physics/input and reached a natural
 game-owned result, with zero target outcome requests after the target gate
 armed, zero recognized fault signals, 60.0 FPS average display/Direct Vulkan

--- a/docs/CURRENT_CHECKPOINT_V2453_EXACT_RIVAL_RENEWAL_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2453_EXACT_RIVAL_RENEWAL_2026-09-01.md
@@ -42,10 +42,12 @@ Each accepted row meets all of these gates:
 | Target | Natural travel | Display min/avg | Vulkan min/avg | Natural RESULT loads | Post-arm developer writes | Fault signals |
 |---|---:|---:|---:|---:|---:|---:|
 | Evo 5 | 289.136 m | 59.8 / 60.0 FPS | 59.8 / 60.0 FPS | 1 | 0 | 0 |
+| Evo 6 | 301.538 m | 59.8 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
 | Keisuke rematch | 787.215 m | 59.8 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
 | Kyoko | 256.297 m | 59.8 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
 | Ryosuke rematch | 360.507 m | 59.8 / 60.0 FPS | 60.0 / 60.0 FPS | 1 | 0 | 0 |
 | Sakamoto | 314.508 m | 59.9 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
+| Smiley | 295.724 m | 59.9 / 60.0 FPS | 59.8 / 60.0 FPS | 1 | 0 | 0 |
 | Sudo rematch | 888.622 m | 59.8 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
 | Wataru | 243.602 m | 59.9 / 60.0 FPS | 59.9 / 60.0 FPS | 1 | 0 | 0 |
 
@@ -58,7 +60,7 @@ without a post-arm developer result write.
 
 The historical accepted ledger still contains natural-result evidence for all
 32 retained rival profiles: 30 Legend profiles and two Bunta profiles. Those
-runs span multiple accepted binaries. The exact-v2453 ledger is **7/32**, not
+runs span multiple accepted binaries. The exact-v2453 ledger is **9/32**, not
 32/32. This checkpoint deliberately keeps those two claims separate.
 
 The broad historical coverage ledger also reports 48/48 defined route/branch
@@ -77,7 +79,7 @@ has been renewed on v2453.
 
 ## Remaining gate
 
-Renew the other 25 rival targets on this exact executable, strictly recheck
+Renew the other 23 rival targets on this exact executable, strictly recheck
 target-arm/result ordering and metrics, and fix any same-build regression found.
 Whole-game readiness still requires broader visual, audio, controller/wheel,
 card/error-branch, cross-driver, and repeated close/restart acceptance.

--- a/tests/test_launcher_policy.py
+++ b/tests/test_launcher_policy.py
@@ -41,6 +41,22 @@ class LauncherPolicyTests(unittest.TestCase):
         self.assertNotIn("C:\\Users\\", LAUNCHER)
         self.assertNotIn("Claude_Handoffs", LAUNCHER)
 
+    def test_moved_card_diagnostic_does_not_contaminate_card_path(self):
+        self.assertIn(
+            'Write-Verbose "Repaired moved card setting: $portableCardPath"',
+            LAUNCHER,
+        )
+        self.assertNotIn(
+            'Write-Output "Repaired moved card setting: $portableCardPath"',
+            LAUNCHER,
+        )
+
+    def test_extracted_files_get_content_retry_before_chd_setup(self):
+        integrity = LAUNCHER.split("$gameFilesReady = Test-Idas3GameFiles", 1)[1]
+        integrity = integrity.split("if (-not $ValidateOnly", 1)[0]
+        self.assertIn("-FullHash -Quiet", integrity)
+        self.assertIn("Start-Sleep -Milliseconds 200", integrity)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/qa/test_windows_launcher_relocation.ps1
+++ b/tools/qa/test_windows_launcher_relocation.ps1
@@ -1,0 +1,88 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = [System.IO.Path]::GetFullPath(
+    (Join-Path $PSScriptRoot '..\..'))
+$launcherSource = Join-Path $repoRoot 'tools\windows\Play Demo.ps1'
+if (-not (Test-Path -LiteralPath $launcherSource -PathType Leaf)) {
+    throw "Launcher source is missing: $launcherSource"
+}
+
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$testRoot = Join-Path $tempBase (
+    'idas3_launcher_relocation_' + [Guid]::NewGuid().ToString('N'))
+$resolvedTestRoot = [System.IO.Path]::GetFullPath($testRoot)
+if (-not $resolvedTestRoot.StartsWith(
+        $tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Refusing unsafe test path: $resolvedTestRoot"
+}
+
+try {
+    $toolsRoot = Join-Path $resolvedTestRoot 'tools'
+    $gameRoot = Join-Path $resolvedTestRoot 'game files'
+    $hostfsRoot = Join-Path $gameRoot 'driveA\HOSTFS'
+    New-Item -ItemType Directory -Path $toolsRoot, $hostfsRoot -Force |
+        Out-Null
+    Copy-Item -LiteralPath $launcherSource `
+        -Destination (Join-Path $resolvedTestRoot 'Play Demo.ps1')
+
+    foreach ($path in @(
+        (Join-Path $resolvedTestRoot 'demo.exe'),
+        (Join-Path $gameRoot 'idas3_main_0C020000.bin'),
+        (Join-Path $gameRoot '.idas3_extraction_complete.json'))) {
+        [System.IO.File]::WriteAllBytes($path, [byte[]]::new(1))
+    }
+
+    $tracePath = Join-Path $resolvedTestRoot 'integrity_calls.txt'
+    $escapedTrace = $tracePath.Replace("'", "''")
+    $integrityFixture = @"
+function Test-Idas3GameFiles {
+    param(
+        [Parameter(Mandatory = `$true)][string]`$Root,
+        [switch]`$FullHash,
+        [switch]`$Quiet
+    )
+    if (`$FullHash) {
+        [System.IO.File]::AppendAllText('$escapedTrace', "full`n")
+        return `$true
+    }
+    [System.IO.File]::AppendAllText('$escapedTrace', "fast`n")
+    return `$false
+}
+"@
+    [System.IO.File]::WriteAllText(
+        (Join-Path $toolsRoot 'GameFilesIntegrity.ps1'),
+        $integrityFixture,
+        [System.Text.UTF8Encoding]::new($false))
+
+    $result = & (Join-Path $resolvedTestRoot 'Play Demo.ps1') `
+        -GameFilesDirectory $gameRoot -ValidateOnly
+    if ($result.Status -ne 'READY') {
+        throw "Relocated launcher did not recover to READY: $($result.Status)"
+    }
+    $calls = @(Get-Content -LiteralPath $tracePath)
+    if ($calls.Count -ne 2 -or $calls[0] -ne 'fast' -or
+        $calls[1] -ne 'full') {
+        throw "Unexpected integrity retry sequence: $($calls -join ',')"
+    }
+
+    [pscustomobject]@{
+        Status = 'PASS'
+        RelocatedBuild = $true
+        IntegritySequence = $calls -join ' -> '
+        GameProcessStarted = $false
+    }
+} finally {
+    if (Test-Path -LiteralPath $resolvedTestRoot) {
+        $resolvedAgain = [System.IO.Path]::GetFullPath($resolvedTestRoot)
+        if (-not $resolvedAgain.StartsWith(
+                $tempBase, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedAgain)).StartsWith(
+                'idas3_launcher_relocation_',
+                [System.StringComparison]::Ordinal)) {
+            throw "Refusing unsafe cleanup path: $resolvedAgain"
+        }
+        Remove-Item -LiteralPath $resolvedAgain -Recurse -Force
+    }
+}

--- a/tools/windows/Play Demo.ps1
+++ b/tools/windows/Play Demo.ps1
@@ -122,6 +122,20 @@ if (-not (Test-Path -LiteralPath $integrityTool -PathType Leaf)) {
 }
 . $integrityTool
 $gameFilesReady = Test-Idas3GameFiles -Root $gameFilesRoot -Quiet
+if (-not $gameFilesReady) {
+    # A just-started GUI launcher, antivirus scanner, or indexer can briefly
+    # disturb the metadata-only pass.  If the extracted layout is present,
+    # retry against file content before incorrectly falling back to CHD setup.
+    $manifest = Join-Path $gameFilesRoot '.idas3_extraction_complete.json'
+    $hostfs = Join-Path $gameFilesRoot 'driveA\HOSTFS'
+    if ($main -and (Test-Path -LiteralPath $main -PathType Leaf) -and
+        (Test-Path -LiteralPath $manifest -PathType Leaf) -and
+        (Test-Path -LiteralPath $hostfs -PathType Container)) {
+        Start-Sleep -Milliseconds 200
+        $gameFilesReady = Test-Idas3GameFiles -Root $gameFilesRoot `
+            -FullHash -Quiet
+    }
+}
 if (-not $ValidateOnly -and -not $gameFilesReady) {
     $setup = Join-Path $PSScriptRoot 'Setup Game Files.ps1'
     if (-not (Test-Path -LiteralPath $setup -PathType Leaf)) {
@@ -333,7 +347,10 @@ $cardPath = if ($CardImage) {
         if (-not (Test-Path -LiteralPath $absoluteCardPath -PathType Leaf) -and
             ((Test-Path -LiteralPath $portableCardPath -PathType Leaf) -or
              -not (Test-Path -LiteralPath $absoluteParent -PathType Container))) {
-            Write-Output "Repaired moved card setting: $portableCardPath"
+            # Keep this diagnostic off the success-output stream.  This block
+            # is an expression assigned to $cardPath, so Write-Output would
+            # turn the result into an array whose first item is this message.
+            Write-Verbose "Repaired moved card setting: $portableCardPath"
             $portableCardPath
         } else {
             $absoluteCardPath


### PR DESCRIPTION
## Summary
- prevent moved-card diagnostics from contaminating the resolved card path
- content-verify extracted files before falling back to CHD setup
- add an isolated moved-build Windows regression
- refresh exact-v2453 natural-result documentation to the authoritative 9/32 ledger

## Verification
- python -m unittest discover -s tests -v (12 passed)
- 	ools/qa/test_windows_launcher_relocation.ps1 (PASS, fast -> full, no game process)
- master Play Demo.ps1 -ValidateOnly (READY)
- private-path audit clean