### PR TITLE
Publish v2454 card reinsertion and verified updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,14 @@ jobs:
         run: cmake --build build --config Release
       - name: Run native smoke test
         run: ctest --test-dir build -C Release --output-on-failure
+
+  windows-launcher:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test verified update and rollback policy
+        shell: powershell
+        run: .\tools\qa\test_windows_updater.ps1
+      - name: Test launcher relocation and integrity retry
+        shell: powershell
+        run: .\tools\qa\test_windows_launcher_relocation.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v2454-card-reinsert-updater — 2026-09-01
+
+- Separated an ejected card's front-sensor/removal state from the next
+  insertion request so a result screen cannot see the same card return before
+  it acknowledges physical removal.
+- Automatically queues the selected exact 207-byte saved card after a normal
+  eject and exposes it only at the next real card prompt/capture boundary.
+- Expanded the card-device test to 27 exact protocol transactions covering
+  early reinsert requests, empty-reader status, delayed capture, automatic
+  second reinsert, and initialization cleanup.
+- Completed a bounded Bunta save/eject/reinsert run on the exact v2454
+  executable with a 207-byte persisted card, zero recognized faults,
+  cooperative exit, and no leftover process.
+- Added a launcher-time GitHub release check that shows the newer version and
+  release date with Yes/No choices and an optional automatic-update checkbox.
+- Added SHA-256 verification, ZIP path/version validation, external in-place
+  installation, preservation of game files/cards/music/logs/settings, and
+  rollback on install failure. Network/update failures fall back to launching
+  the installed version.
+- Added Windows updater and moved-launcher acceptance jobs to public CI and
+  expanded the static launcher policy tests.
+- Re-audited a 17-file Windows x64 public ZIP containing no game data, BIOS,
+  PIC, extracted assets, cards, custom music, logs, captures, generated guest
+  translations, or private paths.
+
 ## Unreleased v2453 exact rival-result renewal — 2026-09-01
 
 - Corrected developer-only natural-detour attempt bookkeeping so a retry win

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of *Initial D Arcade Stage 3* (GDS-0033) for modern Windows PCs.
 > not include game data, a BIOS, card saves, custom music, logs, or extracted
 > assets. You must provide your own legally obtained matching game files.
 
-[**Download Public Early Demo v2445 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2445-direct-persistence)
+[**Download Public Early Demo v2454 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2454-card-reinsert-updater)
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
@@ -29,8 +29,8 @@ PIC only to verify and locally extract the data required by the recompilation.
 
 ## Quick start
 
-1. Download and extract `Public Early Demo v2445.zip` from the
-   [v2445 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2445-direct-persistence).
+1. Download and extract `Public Early Demo v2454.zip` from the
+   [v2454 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2454-card-reinsert-updater).
 2. Place your own matching files in the included `game files` folder:
    - `gds-0033.chd`
    - `317-0384-com.pic`
@@ -42,9 +42,9 @@ Python is not required. Allow roughly 1.3 GB of temporary free space during
 first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 
 Public ZIP SHA-256:
-`301741FEF79AC86CF56F85E9BC19E30D6DC4290833AE3CDF55596C4042F0BB0E`
+`041CBA8943BF7DF43F61B9843FC81C93C5C8107E2FAAF16E16CFA45B69B317AD`
 
-## Current integration progress (v2453 WIP; public demo remains v2445)
+## Current integration progress (v2454 WIP and public early demo)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -69,6 +69,15 @@ Public ZIP SHA-256:
   card is loaded on the next start, and changing cards displays an unsaved-data
   restart warning. Managed selections now remain portable when the extracted
   demo folder is moved or renamed.
+- Post-race ejection now reports the required empty-reader/removal state before
+  queuing the selected saved card for the next prompt. A bounded Bunta result
+  run wrote exactly 207 bytes and crossed this reinsert transition with zero
+  recognized runtime faults.
+- The Windows launcher checks GitHub releases before starting the game. Newer
+  versions are shown with their release date and Yes/No choices; an optional
+  checkbox enables verified automatic installs on future launches. Updates
+  preserve game files, cards, music, logs, and user settings and roll back if
+  installation fails.
 - A self-contained, Python-free setup and integrity checker for user-owned
   inputs.
 - Cooperative renderer shutdown: the program stops new Vulkan presentation,
@@ -161,6 +170,13 @@ Public ZIP SHA-256:
   swapchain path and Safe to the bounded GPU-readback path through one tested
   helper. Direct and Safe no-launch validation both passed, all maintained
   launchers parsed cleanly, and the native v2444 executable was unchanged.
+- The v2454 card/updater checkpoint passed 27 exact card-device transactions,
+  the complete offline product suite, updater selection/digest/extraction/
+  preservation/rollback tests, and the moved-launcher test. Its 17-file public
+  ZIP was then extracted and re-audited with no game data, BIOS, card, music,
+  log, capture, or private path. Bunta win and loss post-result runs plus a
+  three-minute no-input attract run all exited cooperatively without a
+  recognized crash or untranslated-runtime fault.
 - The earlier v2446/schema-5 checkpoint established independent three-field
   direction identity and stopped treating dry/wet condition meshes as road
   direction. The final-v2449 70/70 matrix below supersedes its mixed-build
@@ -225,8 +241,10 @@ failure, and the newest logs. Do not upload game files, extracted assets, card
 data, or copyrighted music.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
+[the v2454 public checkpoint](docs/CURRENT_CHECKPOINT_V2454_CARD_REINSERT_UPDATER_2026-09-01.md)
+for the latest card/updater/release facts,
 [the v2445 public checkpoint](docs/CURRENT_CHECKPOINT_V2445_2026-09-01.md)
-for the latest launcher/release facts,
+for the preceding launcher facts,
 [the v2449 integration checkpoint](docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md)
 for the current native-runtime acceptance,
 [the v2449 route-matrix checkpoint](docs/CURRENT_CHECKPOINT_V2449_ROUTE_MATRIX_2026-09-01.md)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2453 WIP
-Public checkpoint: v2445 Windows x64 early-demo prerelease
+Integration checkpoint: v2454 WIP
+Public checkpoint: v2454 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
 
@@ -16,13 +16,33 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | Course environment maps | Missing logical lookup paths were recovered from two exact user-owned ISO files; rainbow/static maps are corrected | Other courses and weather conditions are not yet audited |
 | JVS/input | 837-13551 identity/features, EEPROM, Maple VBlank/reset, keyboard routes, analog driving input, digital shifter routes, XInput-first device selection, hotplug rescan, paused-menu remapping, controller-operated F1 navigation, adjustable FFB, and saved 0–100% steering smoothing pass focused tests. A product-shared no-window probe found a real attached Xbox controller through `xinput1_4.dll` | Live physical axis/button movement, multiple controller models, wheels, and FFB acceptance remain open |
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; the product's 44.1 kHz stereo PCM format opens on the preferred Windows endpoint; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
-| Card | No-card operation works; a disposable 207-byte card passes insert/load/save/reload; selected managed cards use a move-safe path under the local `card data` folder | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
+| Card | No-card operation works; a disposable 207-byte card passes insert/load/save/eject/removal/reinsert/reload; selected managed cards use a move-safe path under the local `card data` folder. The post-Bunta result path now waits for the required physical-removal status before queuing the saved card for the next prompt | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
 | Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2448 2560x1080 Akagi run held 120.0 FPS minimum/average across 21 moving-race samples, produced 240 distinct frames per two-second sample, and added zero repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
 | Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. One sustained v2440 live Direct run completed exit code 0 and removed its session marker | Repeated live close/restart stress across more GPUs/drivers remains open |
-| Distribution | The v2445 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, and persists the selected Direct/Safe Vulkan path | Clean-machine coverage is limited and the release remains unfinished |
+| Distribution | The v2454 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified updates before launch | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
 
+- v2454 native executable SHA-256:
+  `4E9D607E2F475E38AF8A40BAF6DAE4D8F79CB62C57172D1BB0D1E6FCA065C013`.
+  Its exact card-device suite covers 27 transactions, including an early
+  reinsert request, authentic post-eject empty status, delayed selected-card
+  queue, and a second capture/read cycle.
+- A bounded v2454 Bunta result run wrote exactly 207 bytes, reported
+  `reinsert=queued source=post-eject-removal`, logged zero recognized faults,
+  and exited cooperatively with no remaining game process. Separate Bunta win
+  and loss continuations and a three-minute no-input attract run likewise
+  completed without a recognized crash or untranslated-runtime fault.
+- v2454 public ZIP SHA-256:
+  `041CBA8943BF7DF43F61B9843FC81C93C5C8107E2FAAF16E16CFA45B69B317AD`;
+  audited size is 18,575,765 bytes. Its 17 files include the version marker
+  and source-audited update helpers but no game data, BIOS, PIC, cards, custom
+  music, logs, captures, generated guest code, or private paths.
+- The updater selects the highest newer `vNNNN` prerelease, shows its version
+  and release date, supports optional automatic installs, requires GitHub's
+  SHA-256 asset digest, rejects traversal paths and mismatched version markers,
+  preserves user-owned folders/settings, and rolls back a failed install.
+  Offline update/install tests and the isolated moved-launcher test pass.
 - v2449 identifies the attract sequence's authored black cinematic mattes by
   exact four-vertex mesh/material state and then requires projected native
   x=0..640 coverage before expanding them about the output centre. This keeps
@@ -196,11 +216,13 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 ## Latest WIP truth
 
 The earlier linked-stream/frame-lifecycle and attract-mode-only blockers are no
-longer the active frontier. The v2445 package uses the v2444 native build,
+longer the active frontier. The v2454 package uses the v2454 native build,
 which advances targeted
 menu-to-race and result/save paths, presents retained NAOMI 2 scenes
 continuously, and is available as a public early-demo prerelease that prepares
 data from matching user-owned inputs without a BIOS or Python installation.
+It also repairs delayed card reuse after result-screen ejection and introduces
+a fail-safe GitHub release updater whose network failure cannot block launch.
 
 Recent visual work separated two different causes. Missing ISO9660-truncated
 course lookup names were restored from the user's own dump, removing the

--- a/docs/CURRENT_CHECKPOINT_V2454_CARD_REINSERT_UPDATER_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2454_CARD_REINSERT_UPDATER_2026-09-01.md
@@ -1,0 +1,97 @@
+# v2454 card-reinsert and verified-updater checkpoint
+
+Date: 2026-09-01
+Scope: Windows x64 public early demo, post-result card lifecycle, and
+launcher-time updates
+
+## Product boundary
+
+The executable remains a BIOS-free static SH-4 recompilation. The public ZIP
+contains no game data, NAOMI firmware, security PIC, extracted assets, card
+save, custom music, user log, memory snapshot, generated guest translation, or
+private host path. Users must provide their own matching `gds-0033.chd` and
+`317-0384-com.pic`; setup verifies and extracts them locally without Python.
+
+## Card lifecycle correction
+
+The reader previously allowed a host reinsert request to replace the physical
+front-slot state while the guest was still completing an eject screen. The
+v2454 state machine keeps those events separate:
+
+1. A normal card write persists exactly 207 bytes.
+2. Eject moves that card to the reader's front sensor.
+3. The next ordinary status lets the guest observe that the card was removed.
+4. Only after that observation is the selected saved card queued again.
+5. The card becomes visible at the next genuine frontend/capture request, not
+   during the old result screen.
+
+The exact offline card suite now covers 27 protocol transactions, including an
+early queued insert request, the empty post-eject status, delayed capture,
+automatic second reinsert, and initialization cleanup.
+
+A bounded 60 Hz Bunta result run used a disposable card and the exact v2454
+candidate. It recorded `save=ok bytes=207`, followed by
+`reinsert=queued source=post-eject-removal`, zero recognized errors/runtime
+faults, cooperative exit code 0, and no remaining game process. The resulting
+card was 207 bytes with SHA-256
+`230B7502BA64637F065DF87035B336696D80AD6BE2897421DFAF790CCAAE8A72`.
+
+## Launcher update behavior
+
+Before game setup or launch, the Windows launcher queries this repository's
+release list and selects only the highest release whose tag begins with a
+higher `vNNNN` product version and contains a non-empty ZIP asset. A prompt
+shows the new version and local release date, offers Yes and No, links to the
+GitHub release notes, and includes an optional "Automatically install future
+updates" checkbox.
+
+The updater:
+
+- does not block game launch when GitHub or the network is unavailable;
+- downloads only the selected GitHub release asset;
+- requires and verifies GitHub's `sha256:` asset digest;
+- rejects unsafe archive paths, ambiguous package roots, and a mismatched
+  `PRODUCT_VERSION.txt` marker;
+- installs from an external PowerShell process before the game starts;
+- preserves `game files`, `card data`, `custom music`, `logs`,
+  `idas3_user_settings.ini`, and the updater preference;
+- backs up replaced product files and rolls them back if installation fails;
+- relaunches the packaged frontend after a successful install.
+
+Automatic updates use the same download, digest, archive, version, preservation,
+and rollback checks; they only skip the Yes/No prompt.
+
+## Acceptance
+
+- PowerShell parsing: PASS for launcher, update support, installer, and updater
+  test.
+- Update selection/no-downgrade/preference tests: PASS.
+- Digest, safe extraction, and version-root tests: PASS.
+- In-place install, product replacement, card/settings preservation, and
+  rollback policy tests: PASS.
+- Isolated moved-launcher fast-to-full integrity retry: PASS; no game process
+  started.
+- Full v2454 offline controller/music/card/ELAN/Vulkan/translation/link and
+  no-firmware product suite: PASS.
+- Bunta loss continuation: 240 seconds, two 207-byte saves/eject cycles, zero
+  recognized faults, cooperative exit.
+- Bunta win continuation: 220 seconds, 207-byte save/eject/reinsert, zero
+  recognized faults, cooperative exit.
+- No-input attract run: 180 seconds at 60 Hz, no repeats in sampled output,
+  zero recognized faults, cooperative exit.
+
+These bounded paths do not prove every replay, card-error, campaign, hardware,
+or high-refresh permutation.
+
+## Published artifacts
+
+- Native executable SHA-256:
+  `4E9D607E2F475E38AF8A40BAF6DAE4D8F79CB62C57172D1BB0D1E6FCA065C013`
+- Public ZIP SHA-256:
+  `041CBA8943BF7DF43F61B9843FC81C93C5C8107E2FAAF16E16CFA45B69B317AD`
+- Public ZIP size: 18,575,765 bytes
+- Public ZIP file count: 17
+
+The clean ZIP was extracted into a fresh temporary directory and rechecked for
+its exact runtime hash, version marker, file count, forbidden extensions, and
+private paths before publication.

--- a/docs/PUBLIC_PACKAGE.md
+++ b/docs/PUBLIC_PACKAGE.md
@@ -9,6 +9,10 @@
 - Original project documentation, hashes, diagrams, and a limited set of progress captures.
 - The source-safe Windows launcher and public default settings, including the
   tested Direct/Safe Vulkan presentation mapping.
+- The source-safe GitHub update checker and external installer. They select
+  only a newer versioned release asset, require GitHub's SHA-256 digest,
+  validate the package version and extraction paths, preserve user-owned data,
+  and roll back product-file changes after an install failure.
 
 ## Intentionally excluded
 
@@ -21,4 +25,7 @@
 The Git source package documents and tests the engineering work but cannot boot
 the game by itself. The separate Windows prerelease includes the native runtime
 and local setup tools, but still contains no user-owned game inputs. That
-boundary is intentional.
+boundary is intentional. The v2454 public ZIP adds `PRODUCT_VERSION.txt` and
+the two updater helpers; it contains 17 audited files in total. Update packages
+preserve `game files`, `card data`, `custom music`, `logs`, the user settings
+INI, and the automatic-update preference.

--- a/tests/test_launcher_policy.py
+++ b/tests/test_launcher_policy.py
@@ -12,6 +12,12 @@ LAUNCHER = (ROOT / "tools" / "windows" / "Play Demo.ps1").read_text(
 PUBLIC_SETTINGS = (
     ROOT / "tools" / "windows" / "idas3_user_settings_public.ini"
 ).read_text(encoding="utf-8")
+UPDATER = (ROOT / "tools" / "windows" / "UpdateSupport.ps1").read_text(
+    encoding="utf-8"
+)
+INSTALLER = (ROOT / "tools" / "windows" / "Install Update.ps1").read_text(
+    encoding="utf-8"
+)
 
 
 class LauncherPolicyTests(unittest.TestCase):
@@ -56,6 +62,37 @@ class LauncherPolicyTests(unittest.TestCase):
         integrity = integrity.split("if (-not $ValidateOnly", 1)[0]
         self.assertIn("-FullHash -Quiet", integrity)
         self.assertIn("Start-Sleep -Milliseconds 200", integrity)
+
+    def test_launcher_checks_for_updates_before_game_setup(self):
+        update_call = LAUNCHER.index("Invoke-Idas3UpdateCheck")
+        setup_call = LAUNCHER.index("function Find-GameInputFile")
+        self.assertLess(update_call, setup_call)
+        self.assertIn("$ProductVersion = 2454", LAUNCHER)
+        self.assertIn("[switch]$SkipUpdateCheck", LAUNCHER)
+
+    def test_update_prompt_includes_version_date_and_automatic_choice(self):
+        self.assertIn('"Update $($Update.VersionLabel) is available"', UPDATER)
+        self.assertIn('"Released $($Update.ReleaseDateText)', UPDATER)
+        self.assertIn("Automatically install future updates", UPDATER)
+        self.assertIn("User deferred $($update.VersionLabel)", UPDATER)
+
+    def test_updater_verifies_github_digest_and_package_version(self):
+        self.assertIn("sha256:", UPDATER.lower())
+        self.assertIn("Get-FileHash -LiteralPath $ZipPath -Algorithm SHA256", UPDATER)
+        self.assertIn("PRODUCT_VERSION.txt", UPDATER)
+        self.assertIn("Unsafe path in update package", UPDATER)
+
+    def test_installer_preserves_user_owned_data_and_has_rollback(self):
+        for directory in ("game files", "card data", "custom music", "logs"):
+            self.assertIn(directory, INSTALLER)
+        self.assertIn("idas3_user_settings.ini", INSTALLER)
+        self.assertIn("idas3_launcher_update_settings.json", INSTALLER)
+        self.assertIn("$rollback", INSTALLER)
+
+    def test_update_sources_contain_no_private_absolute_path(self):
+        for source in (UPDATER, INSTALLER):
+            self.assertNotIn("C:\\Users\\", source)
+            self.assertNotIn("Claude_Handoffs", source)
 
 
 if __name__ == "__main__":

--- a/tools/qa/test_windows_updater.ps1
+++ b/tools/qa/test_windows_updater.ps1
@@ -1,0 +1,174 @@
+$ErrorActionPreference = 'Stop'
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+. (Join-Path $repoRoot 'tools\windows\UpdateSupport.ps1')
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw "FAIL: $Message" }
+}
+
+$newRelease = [pscustomobject]@{
+    draft = $false
+    prerelease = $true
+    tag_name = 'v2455-test'
+    name = 'Public Early Demo v2455'
+    published_at = '2026-09-02T03:04:05Z'
+    html_url = 'https://example.invalid/release'
+    assets = @([pscustomobject]@{
+        name = 'Public.Early.Demo.v2455.zip'
+        size = 1234
+        browser_download_url = 'https://example.invalid/update.zip'
+        digest = 'sha256:' + ('a' * 64)
+    })
+}
+$olderRelease = [pscustomobject]@{
+    draft = $false
+    prerelease = $true
+    tag_name = 'v2454-old'
+    name = 'Old'
+    published_at = '2026-09-01T00:00:00Z'
+    html_url = 'https://example.invalid/old'
+    assets = @([pscustomobject]@{
+        name = 'old.zip'; size = 1
+        browser_download_url = 'https://example.invalid/old.zip'
+        digest = 'sha256:' + ('b' * 64)
+    })
+}
+$available = Get-Idas3AvailableUpdate -CurrentVersion 2454 `
+    -Releases @($olderRelease, $newRelease)
+Assert-True ($available.Version -eq 2455) `
+    'release parser selects the highest newer prerelease'
+Assert-True (-not (Get-Idas3AvailableUpdate -CurrentVersion 2455 `
+    -Releases @($olderRelease, $newRelease))) `
+    'current version does not update to itself or an older release'
+
+$testRoot = Join-Path $env:TEMP ('idas3_updater_test_' + [Guid]::NewGuid().ToString('N'))
+$sourceRoot = Join-Path $testRoot 'source'
+$destinationRoot = Join-Path $testRoot 'destination'
+$workingRoot = Join-Path $testRoot 'working'
+$extractRoot = Join-Path $testRoot 'extract'
+foreach ($path in @($sourceRoot, $destinationRoot, $workingRoot)) {
+    New-Item -ItemType Directory -Path $path -Force | Out-Null
+}
+try {
+    Set-Idas3AutomaticUpdatePreference -BuildRoot $destinationRoot -Enabled $true
+    Assert-True (Get-Idas3AutomaticUpdatePreference `
+        -BuildRoot $destinationRoot) 'automatic update preference round-trips'
+
+    foreach ($path in @(
+        (Join-Path $sourceRoot 'card data'),
+        (Join-Path $sourceRoot 'game files'),
+        (Join-Path $sourceRoot 'custom music'),
+        (Join-Path $destinationRoot 'card data'),
+        (Join-Path $destinationRoot 'game files'),
+        (Join-Path $destinationRoot 'custom music'))) {
+        New-Item -ItemType Directory -Path $path -Force | Out-Null
+    }
+    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'PRODUCT_VERSION.txt'), '2455')
+    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'demo.exe'), 'new-demo')
+    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'Play Demo.ps1'), 'new-launcher')
+    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'README.txt'), 'new-readme')
+    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'idas3_user_settings.ini'), 'bad-default')
+    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'card data\player.card'), 'bad-card')
+    [System.IO.File]::WriteAllText((Join-Path $destinationRoot 'demo.exe'), 'old-demo')
+    [System.IO.File]::WriteAllText((Join-Path $destinationRoot 'idas3_user_settings.ini'), 'user-settings')
+    [System.IO.File]::WriteAllText((Join-Path $destinationRoot 'card data\player.card'), 'user-card')
+
+    & (Join-Path $repoRoot 'tools\windows\Install Update.ps1') `
+        -SourceRoot $sourceRoot -DestinationRoot $destinationRoot `
+        -WorkingRoot $workingRoot -ExpectedVersion 2455 `
+        -NoRelaunch -KeepWorkingDirectory -TestMode
+    $installedDemoPath = Join-Path $destinationRoot 'demo.exe'
+    $installedDemo = Get-Content -LiteralPath $installedDemoPath -Raw
+    Assert-True ($installedDemo -eq 'new-demo') `
+        'installer replaces product-controlled files'
+    $installedSettingsPath = Join-Path $destinationRoot 'idas3_user_settings.ini'
+    $installedSettings = Get-Content -LiteralPath $installedSettingsPath -Raw
+    Assert-True ($installedSettings -eq 'user-settings') `
+        'installer preserves user settings'
+    $installedCardPath = Join-Path $destinationRoot 'card data\player.card'
+    $installedCard = Get-Content -LiteralPath $installedCardPath -Raw
+    Assert-True ($installedCard -eq 'user-card') `
+        'installer preserves card data'
+
+    $rollbackSource = Join-Path $testRoot 'rollback-source'
+    $rollbackDestination = Join-Path $testRoot 'rollback-destination'
+    $rollbackWorking = Join-Path $testRoot 'rollback-working'
+    foreach ($path in @(
+        $rollbackSource, $rollbackDestination, $rollbackWorking)) {
+        New-Item -ItemType Directory -Path $path -Force | Out-Null
+    }
+    [System.IO.File]::WriteAllText(
+        (Join-Path $rollbackSource 'PRODUCT_VERSION.txt'), '2455')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $rollbackSource 'demo.exe'), 'new-rollback-demo')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $rollbackSource 'Play Demo.ps1'), 'new-rollback-launcher')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $rollbackDestination 'demo.exe'), 'old-rollback-demo')
+    $rollbackFailed = $false
+    try {
+        & (Join-Path $repoRoot 'tools\windows\Install Update.ps1') `
+            -SourceRoot $rollbackSource `
+            -DestinationRoot $rollbackDestination `
+            -WorkingRoot $rollbackWorking -ExpectedVersion 2455 `
+            -NoRelaunch -KeepWorkingDirectory -TestMode `
+            -TestFailAfterCopies 2
+    } catch {
+        $rollbackFailed = $true
+    }
+    Assert-True $rollbackFailed 'injected mid-install failure is reported'
+    Assert-True ((Get-Content -LiteralPath `
+            (Join-Path $rollbackDestination 'demo.exe') -Raw) -eq
+        'old-rollback-demo') 'failed install restores replaced product file'
+    Assert-True (-not (Test-Path -LiteralPath `
+            (Join-Path $rollbackDestination 'PRODUCT_VERSION.txt'))) `
+        'failed install removes newly created product file'
+
+    $zipPath = Join-Path $testRoot 'verified.zip'
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($sourceRoot, $zipPath)
+    $digest = 'sha256:' + (Get-FileHash -LiteralPath $zipPath `
+        -Algorithm SHA256).Hash.ToLowerInvariant()
+    $expanded = Expand-Idas3VerifiedUpdatePackage -ZipPath $zipPath `
+        -ExpectedDigest $digest -ExpectedVersion 2455 `
+        -ExtractRoot $extractRoot
+    $expandedFull = [System.IO.Path]::GetFullPath([string]$expanded).
+        TrimEnd('\', '/')
+    $extractFull = [System.IO.Path]::GetFullPath($extractRoot).
+        TrimEnd('\', '/')
+    Assert-True ($expandedFull -ieq $extractFull) `
+        'verified package extracts and locates its versioned product root'
+
+    $unsafeZip = Join-Path $testRoot 'unsafe.zip'
+    $unsafeExtract = Join-Path $testRoot 'unsafe-extract'
+    $escapedPath = Join-Path $testRoot 'escaped.txt'
+    $archive = [System.IO.Compression.ZipFile]::Open(
+        $unsafeZip, [System.IO.Compression.ZipArchiveMode]::Create)
+    try {
+        $entry = $archive.CreateEntry('../escaped.txt')
+        $writer = New-Object System.IO.StreamWriter($entry.Open())
+        try { $writer.Write('must-not-escape') } finally { $writer.Dispose() }
+    } finally {
+        $archive.Dispose()
+    }
+    $unsafeRejected = $false
+    try {
+        $unsafeDigest = 'sha256:' + (Get-FileHash -LiteralPath $unsafeZip `
+            -Algorithm SHA256).Hash.ToLowerInvariant()
+        [void](Expand-Idas3VerifiedUpdatePackage -ZipPath $unsafeZip `
+            -ExpectedDigest $unsafeDigest -ExpectedVersion 2455 `
+            -ExtractRoot $unsafeExtract)
+    } catch {
+        $unsafeRejected = $_.Exception.Message -match 'Unsafe path'
+    }
+    Assert-True $unsafeRejected 'archive traversal path is rejected'
+    Assert-True (-not (Test-Path -LiteralPath $escapedPath)) `
+        'archive traversal writes nothing outside extraction root'
+} finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        [System.IO.Directory]::Delete($testRoot, $true)
+    }
+}
+
+Write-Output 'windows updater tests: PASS'

--- a/tools/windows/Install Update.ps1
+++ b/tools/windows/Install Update.ps1
@@ -1,0 +1,154 @@
+param(
+    [Parameter(Mandatory = $true)][string]$SourceRoot,
+    [Parameter(Mandatory = $true)][string]$DestinationRoot,
+    [Parameter(Mandatory = $true)][string]$WorkingRoot,
+    [Parameter(Mandatory = $true)][int]$ExpectedVersion,
+    [string]$WaitForProcessIds = '',
+    [string]$RelaunchPath = '',
+    [switch]$NoRelaunch,
+    [switch]$KeepWorkingDirectory,
+    [switch]$TestMode,
+    [ValidateRange(0, 1000)]
+    [int]$TestFailAfterCopies = 0
+)
+
+$ErrorActionPreference = 'Stop'
+$source = [System.IO.Path]::GetFullPath($SourceRoot)
+$destination = [System.IO.Path]::GetFullPath($DestinationRoot)
+$working = [System.IO.Path]::GetFullPath($WorkingRoot)
+$destinationPrefix = $destination.TrimEnd('\', '/') +
+    [System.IO.Path]::DirectorySeparatorChar
+
+function Write-InstallerLog {
+    param([string]$Message)
+    try {
+        $logDirectory = Join-Path $destination 'logs'
+        New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        [System.IO.File]::AppendAllText(
+            (Join-Path $logDirectory 'update_install.log'),
+            ('[{0}] {1}{2}' -f (Get-Date).ToString('o'), $Message,
+                [Environment]::NewLine),
+            [System.Text.UTF8Encoding]::new($false))
+    } catch {}
+}
+
+try {
+    foreach ($idText in @($WaitForProcessIds -split ',')) {
+        $waitId = 0
+        if (-not [int]::TryParse($idText, [ref]$waitId) -or
+            $waitId -le 0 -or $waitId -eq $PID) { continue }
+        $process = Get-Process -Id $waitId -ErrorAction SilentlyContinue
+        if ($process) { $process.WaitForExit(60000) | Out-Null }
+    }
+
+    $markerPath = Join-Path $source 'PRODUCT_VERSION.txt'
+    $marker = (Get-Content -LiteralPath $markerPath -Raw).Trim()
+    if ($marker -notmatch '^v?(?<number>[0-9]+)$' -or
+        [int]$matches.number -ne $ExpectedVersion) {
+        throw "Staged package version '$marker' does not match v$ExpectedVersion."
+    }
+    foreach ($required in @('demo.exe', 'Play Demo.ps1')) {
+        if (-not (Test-Path -LiteralPath (Join-Path $source $required) `
+                -PathType Leaf)) {
+            throw "Staged package is missing $required."
+        }
+    }
+
+    $rollback = Join-Path $working 'rollback'
+    New-Item -ItemType Directory -Path $rollback -Force | Out-Null
+    $createdFiles = New-Object System.Collections.Generic.List[string]
+    $protectedDirectories = @('game files', 'card data', 'custom music', 'logs')
+    $protectedFiles = @(
+        'idas3_user_settings.ini',
+        'idas3_launcher_update_settings.json'
+    )
+    $copiedFiles = 0
+    try {
+        foreach ($file in Get-ChildItem -LiteralPath $source -Recurse -File) {
+            $relative = $file.FullName.Substring($source.Length).TrimStart('\', '/')
+            $parts = $relative -split '[\\/]'
+            if ($parts[0] -in $protectedDirectories -or
+                ($parts.Count -eq 1 -and $parts[0] -in $protectedFiles)) {
+                continue
+            }
+            $target = [System.IO.Path]::GetFullPath(
+                (Join-Path $destination $relative))
+            if (-not $target.StartsWith(
+                    $destinationPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Unsafe install path: $relative"
+            }
+            $targetParent = Split-Path -Parent $target
+            New-Item -ItemType Directory -Path $targetParent -Force | Out-Null
+            if (Test-Path -LiteralPath $target -PathType Leaf) {
+                $backup = Join-Path $rollback $relative
+                New-Item -ItemType Directory -Path (Split-Path -Parent $backup) `
+                    -Force | Out-Null
+                Copy-Item -LiteralPath $target -Destination $backup -Force
+            } else {
+                $createdFiles.Add($target)
+            }
+            Copy-Item -LiteralPath $file.FullName -Destination $target -Force
+            ++$copiedFiles
+            if ($TestMode -and $TestFailAfterCopies -gt 0 -and
+                $copiedFiles -ge $TestFailAfterCopies) {
+                throw "Injected updater test failure after $copiedFiles copies."
+            }
+        }
+
+        $installedMarkerPath = Join-Path $destination 'PRODUCT_VERSION.txt'
+        $installedMarker = (Get-Content -LiteralPath $installedMarkerPath -Raw).Trim()
+        if ($installedMarker -notmatch '^v?(?<number>[0-9]+)$' -or
+            [int]$matches.number -ne $ExpectedVersion) {
+            throw 'Installed version marker verification failed.'
+        }
+        if (-not (Test-Path -LiteralPath (Join-Path $destination 'demo.exe') `
+                -PathType Leaf)) {
+            throw 'Installed executable verification failed.'
+        }
+    } catch {
+        foreach ($backupFile in Get-ChildItem -LiteralPath $rollback -Recurse -File) {
+            $relative = $backupFile.FullName.Substring($rollback.Length).TrimStart('\', '/')
+            $target = Join-Path $destination $relative
+            New-Item -ItemType Directory -Path (Split-Path -Parent $target) `
+                -Force | Out-Null
+            Copy-Item -LiteralPath $backupFile.FullName -Destination $target -Force
+        }
+        foreach ($created in $createdFiles) {
+            if (Test-Path -LiteralPath $created -PathType Leaf) {
+                [System.IO.File]::Delete($created)
+            }
+        }
+        throw
+    }
+
+    Write-InstallerLog "Installed verified update v$ExpectedVersion."
+    if (-not $NoRelaunch -and $RelaunchPath -and
+        (Test-Path -LiteralPath $RelaunchPath -PathType Leaf)) {
+        Start-Process -FilePath $RelaunchPath -WorkingDirectory $destination | Out-Null
+    }
+    if (-not $KeepWorkingDirectory) {
+        try {
+            $localData = [Environment]::GetFolderPath('LocalApplicationData')
+            $localUpdateBase = Join-Path $localData 'InitialDAS3Recomp\updates'
+            $allowedRoot = [System.IO.Path]::GetFullPath(
+                $localUpdateBase).TrimEnd('\', '/') +
+                [System.IO.Path]::DirectorySeparatorChar
+            if ($working.StartsWith(
+                    $allowedRoot, [StringComparison]::OrdinalIgnoreCase)) {
+                [System.IO.Directory]::Delete($working, $true)
+            }
+        } catch {}
+    }
+    if ($TestMode) { return }
+    exit 0
+} catch {
+    Write-InstallerLog "Install failed: $($_.Exception.Message)"
+    if ($TestMode) { throw }
+    try {
+        Add-Type -AssemblyName System.Windows.Forms
+        [System.Windows.Forms.MessageBox]::Show(
+            "The verified update could not be installed. The existing files were restored.`r`n`r`n$($_.Exception.Message)",
+            'Initial D Recomp Update Failed', 'OK', 'Error') | Out-Null
+    } catch {}
+    exit 1
+}

--- a/tools/windows/Play Demo.ps1
+++ b/tools/windows/Play Demo.ps1
@@ -36,7 +36,8 @@ param(
     [switch]$PresentationTrace,
     [switch]$DeveloperRaceOutcomes,
     [string]$RecordInputs = '',
-    [string]$PlaybackInputs = ''
+    [string]$PlaybackInputs = '',
+    [switch]$SkipUpdateCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -57,11 +58,33 @@ trap {
 $handoffRoot = $PSScriptRoot
 $buildRoot = $PSScriptRoot
 $logRoot = Join-Path $PSScriptRoot 'logs'
+$ProductVersion = 2454
 $currentExecutable = Join-Path $buildRoot 'demo.exe'
 $exe = if ($Exe) {
     (Resolve-Path -LiteralPath $Exe).Path
 } else {
     $currentExecutable
+}
+
+# A launcher-side updater can replace the product before demo.exe starts and
+# therefore does not need to modify a running game process. Source-tree tests
+# keep UpdateSupport beside this file; packaged builds place it under tools.
+if (-not $ValidateOnly) {
+    $updateSupport = @(
+        (Join-Path $PSScriptRoot 'tools\UpdateSupport.ps1'),
+        (Join-Path $PSScriptRoot 'UpdateSupport.ps1')
+    ) | Where-Object {
+        Test-Path -LiteralPath $_ -PathType Leaf
+    } | Select-Object -First 1
+    if ($updateSupport) {
+        . $updateSupport
+        if (Invoke-Idas3UpdateCheck -CurrentVersion $ProductVersion `
+                -BuildRoot $buildRoot -Skip:$SkipUpdateCheck) {
+            # The verified external installer waits for a packaged GUI parent
+            # when necessary, installs in place, then relaunches once.
+            return
+        }
+    }
 }
 
 function Find-GameInputFile {

--- a/tools/windows/UpdateSupport.ps1
+++ b/tools/windows/UpdateSupport.ps1
@@ -1,0 +1,381 @@
+$script:Idas3UpdaterModuleRoot = $PSScriptRoot
+$script:Idas3UpdateRepository =
+    'distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-'
+$script:Idas3UpdateSettingsName = 'idas3_launcher_update_settings.json'
+
+function Write-Idas3UpdateLog {
+    param(
+        [Parameter(Mandatory = $true)][string]$BuildRoot,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+    try {
+        $logDirectory = Join-Path $BuildRoot 'logs'
+        New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+        $line = '[{0}] {1}{2}' -f (Get-Date).ToString('o'), $Message,
+            [Environment]::NewLine
+        [System.IO.File]::AppendAllText(
+            (Join-Path $logDirectory 'update_check.log'), $line,
+            [System.Text.UTF8Encoding]::new($false))
+    } catch {
+        # Update telemetry must never prevent the game from starting.
+    }
+}
+
+function Get-Idas3AutomaticUpdatePreference {
+    param([Parameter(Mandatory = $true)][string]$BuildRoot)
+    $path = Join-Path $BuildRoot $script:Idas3UpdateSettingsName
+    try {
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $false }
+        $saved = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+        return $saved.AutomaticUpdates -eq $true
+    } catch {
+        Write-Idas3UpdateLog -BuildRoot $BuildRoot `
+            -Message "Ignoring unreadable update preference: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+function Set-Idas3AutomaticUpdatePreference {
+    param(
+        [Parameter(Mandatory = $true)][string]$BuildRoot,
+        [Parameter(Mandatory = $true)][bool]$Enabled
+    )
+    $path = Join-Path $BuildRoot $script:Idas3UpdateSettingsName
+    $temporary = "$path.new"
+    $json = [ordered]@{
+        AutomaticUpdates = $Enabled
+        UpdatedUtc = [DateTime]::UtcNow.ToString('o')
+    } | ConvertTo-Json
+    [System.IO.File]::WriteAllText(
+        $temporary, $json + [Environment]::NewLine,
+        [System.Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $temporary -Destination $path -Force
+}
+
+function Get-Idas3AvailableUpdate {
+    param(
+        [Parameter(Mandatory = $true)][int]$CurrentVersion,
+        [object[]]$Releases,
+        [string]$Repository = $script:Idas3UpdateRepository
+    )
+    if (-not $PSBoundParameters.ContainsKey('Releases')) {
+        [Net.ServicePointManager]::SecurityProtocol =
+            [Net.ServicePointManager]::SecurityProtocol -bor
+            [Net.SecurityProtocolType]::Tls12
+        $headers = @{
+            Accept = 'application/vnd.github+json'
+            'User-Agent' = 'IDAS3-Native-Recomp-Updater'
+            'X-GitHub-Api-Version' = '2022-11-28'
+        }
+        $uri = "https://api.github.com/repos/$Repository/releases?per_page=30"
+        # Windows PowerShell can preserve a top-level JSON array as one object
+        # whose properties are arrays. Sending it through the pipeline expands
+        # the individual release records before the selector combines fields.
+        $response = Invoke-RestMethod -Uri $uri -Headers $headers `
+            -Method Get -TimeoutSec 6
+        $Releases = @($response | ForEach-Object { $_ })
+    }
+
+    $candidates = @()
+    foreach ($release in @($Releases)) {
+        if ($release.draft -eq $true) { continue }
+        $tag = [string]$release.tag_name
+        if ($tag -notmatch '^v(?<number>[0-9]+)(?:[^0-9].*)?$') { continue }
+        $version = [int]$matches.number
+        $zipAssets = @($release.assets | Where-Object {
+            [string]$_.name -match '\.zip$' -and [int64]$_.size -gt 0
+        })
+        if ($zipAssets.Count -eq 0) { continue }
+        $asset = @($zipAssets | Sort-Object @{
+            Expression = {
+                if ([string]$_.name -match '(?i)public.*early.*demo') { 0 } else { 1 }
+            }
+        }, name)[0]
+        $published = [DateTimeOffset]::MinValue
+        if ($release.published_at) {
+            try { $published = [DateTimeOffset]$release.published_at } catch {}
+        }
+        $candidates += [pscustomobject]@{
+            Version = $version
+            VersionLabel = "v$version"
+            Name = [string]$release.name
+            Tag = $tag
+            PublishedAt = $published
+            ReleaseDateText = if ($published -ne [DateTimeOffset]::MinValue) {
+                $published.ToLocalTime().ToString('MMMM d, yyyy')
+            } else { 'an unknown date' }
+            ReleaseUrl = [string]$release.html_url
+            AssetName = [string]$asset.name
+            AssetUrl = [string]$asset.browser_download_url
+            AssetDigest = [string]$asset.digest
+            AssetSize = [int64]$asset.size
+        }
+    }
+    $available = @($candidates | Where-Object {
+        $_.Version -gt $CurrentVersion
+    } | Sort-Object Version, PublishedAt -Descending | Select-Object -First 1)
+    if ($available.Count -eq 0) { return $null }
+    return $available[0]
+}
+
+function Show-Idas3UpdatePrompt {
+    param([Parameter(Mandatory = $true)]$Update)
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -AssemblyName System.Drawing
+
+    $form = New-Object System.Windows.Forms.Form
+    $form.Text = 'Initial D Arcade Stage 3 Recomp Update'
+    $form.StartPosition = 'CenterScreen'
+    $form.FormBorderStyle = 'FixedDialog'
+    $form.MaximizeBox = $false
+    $form.MinimizeBox = $false
+    $form.ClientSize = New-Object System.Drawing.Size(540, 245)
+    $form.Font = New-Object System.Drawing.Font('Segoe UI', 10)
+
+    $heading = New-Object System.Windows.Forms.Label
+    $heading.Location = New-Object System.Drawing.Point(24, 20)
+    $heading.Size = New-Object System.Drawing.Size(492, 32)
+    $heading.Font = New-Object System.Drawing.Font('Segoe UI Semibold', 14)
+    $heading.Text = "Update $($Update.VersionLabel) is available"
+    $form.Controls.Add($heading)
+
+    $details = New-Object System.Windows.Forms.Label
+    $details.Location = New-Object System.Drawing.Point(26, 62)
+    $details.Size = New-Object System.Drawing.Size(488, 52)
+    $details.Text = "Released $($Update.ReleaseDateText).`r`nDownload the verified update before starting the game?"
+    $form.Controls.Add($details)
+
+    $releaseLink = New-Object System.Windows.Forms.LinkLabel
+    $releaseLink.Location = New-Object System.Drawing.Point(26, 119)
+    $releaseLink.Size = New-Object System.Drawing.Size(200, 25)
+    $releaseLink.Text = 'View release notes on GitHub'
+    $releaseUrl = [string]$Update.ReleaseUrl
+    $releaseLink.Add_LinkClicked({
+        if ($releaseUrl) { Start-Process $releaseUrl }
+    })
+    $form.Controls.Add($releaseLink)
+
+    $automatic = New-Object System.Windows.Forms.CheckBox
+    $automatic.Location = New-Object System.Drawing.Point(29, 153)
+    $automatic.Size = New-Object System.Drawing.Size(360, 28)
+    $automatic.Text = 'Automatically install future updates'
+    $form.Controls.Add($automatic)
+
+    $yes = New-Object System.Windows.Forms.Button
+    $yes.Location = New-Object System.Drawing.Point(330, 196)
+    $yes.Size = New-Object System.Drawing.Size(88, 32)
+    $yes.Text = 'Yes'
+    $yes.Add_Click({ $form.Tag = 'yes'; $form.Close() })
+    $form.Controls.Add($yes)
+    $form.AcceptButton = $yes
+
+    $no = New-Object System.Windows.Forms.Button
+    $no.Location = New-Object System.Drawing.Point(428, 196)
+    $no.Size = New-Object System.Drawing.Size(88, 32)
+    $no.Text = 'No'
+    $no.Add_Click({ $form.Tag = 'no'; $form.Close() })
+    $form.Controls.Add($no)
+    $form.CancelButton = $no
+
+    $form.ShowDialog() | Out-Null
+    return [pscustomobject]@{
+        Install = $form.Tag -eq 'yes'
+        AutomaticUpdates = $form.Tag -eq 'yes' -and $automatic.Checked
+    }
+}
+
+function Expand-Idas3VerifiedUpdatePackage {
+    param(
+        [Parameter(Mandatory = $true)][string]$ZipPath,
+        [Parameter(Mandatory = $true)][string]$ExpectedDigest,
+        [Parameter(Mandatory = $true)][int]$ExpectedVersion,
+        [Parameter(Mandatory = $true)][string]$ExtractRoot
+    )
+    if ($ExpectedDigest -notmatch '^(?i)sha256:(?<hash>[0-9a-f]{64})$') {
+        throw 'GitHub did not provide a usable SHA-256 digest for this update.'
+    }
+    $expectedHash = $matches.hash.ToUpperInvariant()
+    $actualHash = (Get-FileHash -LiteralPath $ZipPath -Algorithm SHA256).Hash
+    if ($actualHash -ne $expectedHash) {
+        throw "Update checksum mismatch (expected $expectedHash, received $actualHash)."
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    New-Item -ItemType Directory -Path $ExtractRoot -Force | Out-Null
+    $rootFull = [System.IO.Path]::GetFullPath($ExtractRoot)
+    $rootPrefix = $rootFull.TrimEnd('\', '/') +
+        [System.IO.Path]::DirectorySeparatorChar
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+    try {
+        foreach ($entry in $archive.Entries) {
+            if (-not $entry.FullName) { continue }
+            $relative = $entry.FullName.Replace('/',
+                [System.IO.Path]::DirectorySeparatorChar)
+            $destination = [System.IO.Path]::GetFullPath(
+                (Join-Path $rootFull $relative))
+            if (-not $destination.StartsWith(
+                    $rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Unsafe path in update package: $($entry.FullName)"
+            }
+            if ($entry.FullName.EndsWith('/') -or
+                $entry.FullName.EndsWith('\')) {
+                New-Item -ItemType Directory -Path $destination -Force | Out-Null
+                continue
+            }
+            $parent = Split-Path -Parent $destination
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+            try {
+                [System.IO.Compression.ZipFileExtensions]::ExtractToFile(
+                    $entry, $destination, $true)
+            } catch {
+                throw "Could not extract '$($entry.FullName)' to '$destination': $($_.Exception.Message)"
+            }
+        }
+    } finally {
+        $archive.Dispose()
+    }
+
+    $packageRoots = @(Get-ChildItem -LiteralPath $rootFull -Recurse -File `
+        -Filter 'PRODUCT_VERSION.txt' | ForEach-Object {
+            $candidate = $_.Directory.FullName
+            if ((Test-Path -LiteralPath (Join-Path $candidate 'demo.exe') `
+                    -PathType Leaf) -and
+                (Test-Path -LiteralPath (Join-Path $candidate 'Play Demo.ps1') `
+                    -PathType Leaf)) { $candidate }
+        } | Select-Object -Unique)
+    if ($packageRoots.Count -ne 1) {
+        throw 'The verified ZIP does not contain exactly one complete demo package.'
+    }
+    $markerPath = Join-Path $packageRoots[0] 'PRODUCT_VERSION.txt'
+    $marker = (Get-Content -LiteralPath $markerPath -Raw).Trim()
+    if ($marker -notmatch '^v?(?<number>[0-9]+)$' -or
+        [int]$matches.number -ne $ExpectedVersion) {
+        throw "The ZIP version marker '$marker' does not match v$ExpectedVersion."
+    }
+    return $packageRoots[0]
+}
+
+function Start-Idas3StagedUpdate {
+    param(
+        [Parameter(Mandatory = $true)]$Update,
+        [Parameter(Mandatory = $true)][string]$BuildRoot
+    )
+    $localData = [Environment]::GetFolderPath('LocalApplicationData')
+    if (-not $localData) { throw 'Windows did not provide a Local AppData folder.' }
+    $workingRoot = Join-Path (Join-Path $localData 'InitialDAS3Recomp\updates') `
+        (('{0}-{1}' -f $Update.VersionLabel, [Guid]::NewGuid().ToString('N')))
+    New-Item -ItemType Directory -Path $workingRoot -Force | Out-Null
+    try {
+        $assetFileName = [System.IO.Path]::GetFileName([string]$Update.AssetName)
+        if (-not $assetFileName -or $assetFileName -ne [string]$Update.AssetName) {
+            throw 'GitHub returned an unsafe update asset name.'
+        }
+        $zipPath = Join-Path $workingRoot $assetFileName
+        $oldProgress = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        try {
+            Invoke-WebRequest -Uri $Update.AssetUrl -OutFile $zipPath `
+                -UseBasicParsing -TimeoutSec 120 -Headers @{
+                    'User-Agent' = 'IDAS3-Native-Recomp-Updater'
+                }
+        } finally {
+            $ProgressPreference = $oldProgress
+        }
+        $extractRoot = Join-Path $workingRoot 'package'
+        $packageRoot = Expand-Idas3VerifiedUpdatePackage -ZipPath $zipPath `
+            -ExpectedDigest $Update.AssetDigest `
+            -ExpectedVersion $Update.Version -ExtractRoot $extractRoot
+
+        $installerSource = Join-Path $script:Idas3UpdaterModuleRoot `
+            'Install Update.ps1'
+        if (-not (Test-Path -LiteralPath $installerSource -PathType Leaf)) {
+            throw "The update installer helper is missing: $installerSource"
+        }
+        $installer = Join-Path $workingRoot 'Install Update.ps1'
+        Copy-Item -LiteralPath $installerSource -Destination $installer -Force
+
+        $waitIds = @()
+        try {
+            $current = Get-CimInstance Win32_Process -Filter "ProcessId=$PID"
+            $parent = Get-CimInstance Win32_Process `
+                -Filter "ProcessId=$($current.ParentProcessId)"
+            $buildPrefix = [System.IO.Path]::GetFullPath($BuildRoot).TrimEnd('\', '/') +
+                [System.IO.Path]::DirectorySeparatorChar
+            if ($parent.ExecutablePath -and
+                [System.IO.Path]::GetFullPath($parent.ExecutablePath).StartsWith(
+                    $buildPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                # The packaged GUI frontend is inside the product folder and
+                # Windows locks that executable while it waits for this script.
+                $waitIds += [int]$parent.ProcessId
+            }
+        } catch {}
+        $relaunch = Join-Path $BuildRoot `
+            'Initial D Arcade Stage 3 Recompiled.exe'
+        if (-not (Test-Path -LiteralPath $relaunch -PathType Leaf)) {
+            $relaunch = Join-Path $BuildRoot 'Play Demo.cmd'
+        }
+        $quote = { param([string]$Value) '"' + $Value.Replace('"', '""') + '"' }
+        $arguments = @(
+            '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', (& $quote $installer),
+            '-SourceRoot', (& $quote $packageRoot),
+            '-DestinationRoot', (& $quote $BuildRoot),
+            '-WorkingRoot', (& $quote $workingRoot),
+            '-ExpectedVersion', [string]$Update.Version,
+            '-WaitForProcessIds', (& $quote ($waitIds -join ',')),
+            '-RelaunchPath', (& $quote $relaunch)
+        ) -join ' '
+        Start-Process -FilePath 'powershell.exe' -ArgumentList $arguments `
+            -WindowStyle Hidden | Out-Null
+        Write-Idas3UpdateLog -BuildRoot $BuildRoot `
+            -Message "Verified $($Update.VersionLabel); staged installer dispatched."
+        return $true
+    } catch {
+        Write-Idas3UpdateLog -BuildRoot $BuildRoot `
+            -Message "Update staging failed: $($_.Exception.Message)"
+        throw
+    }
+}
+
+function Invoke-Idas3UpdateCheck {
+    param(
+        [Parameter(Mandatory = $true)][int]$CurrentVersion,
+        [Parameter(Mandatory = $true)][string]$BuildRoot,
+        [switch]$Skip
+    )
+    if ($Skip -or $env:IDAS3_DISABLE_UPDATE_CHECK -eq '1') { return $false }
+    try {
+        $update = Get-Idas3AvailableUpdate -CurrentVersion $CurrentVersion
+    } catch {
+        Write-Idas3UpdateLog -BuildRoot $BuildRoot `
+            -Message "Update check unavailable; continuing launch: $($_.Exception.Message)"
+        return $false
+    }
+    if (-not $update) { return $false }
+
+    $automatic = Get-Idas3AutomaticUpdatePreference -BuildRoot $BuildRoot
+    $install = $automatic
+    if (-not $automatic) {
+        $choice = Show-Idas3UpdatePrompt -Update $update
+        $install = $choice.Install
+        if ($choice.AutomaticUpdates) {
+            Set-Idas3AutomaticUpdatePreference -BuildRoot $BuildRoot -Enabled $true
+        }
+    }
+    if (-not $install) {
+        Write-Idas3UpdateLog -BuildRoot $BuildRoot `
+            -Message "User deferred $($update.VersionLabel)."
+        return $false
+    }
+
+    try {
+        return Start-Idas3StagedUpdate -Update $update -BuildRoot $BuildRoot
+    } catch {
+        try {
+            Add-Type -AssemblyName System.Windows.Forms
+            [System.Windows.Forms.MessageBox]::Show(
+                "The update could not be installed, so the current version will start normally.`r`n`r`n$($_.Exception.Message)",
+                'Initial D Recomp Update Failed', 'OK', 'Error') | Out-Null
+        } catch {}
+        return $false
+    }
+}


### PR DESCRIPTION
Publishes the audited v2454 public early demo support files and documentation.

- fixes post-result card removal/reinsert ordering, verified in a bounded Bunta flow
- adds launcher-time GitHub update checks with version/date prompt and optional automatic installs
- verifies SHA-256, ZIP paths, and package version
- preserves user-owned data and rolls back failed installs
- adds Windows updater and relocation CI coverage

Local gates: 17 Python tests, 4 native CTest tests, updater rollback/traversal QA, launcher relocation QA, PowerShell parse checks, and a fresh 17-file package audit.