### PR TITLE
Publish v2456 Direct Vulkan retry checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v2456-direct-vulkan-retry — 2026-09-01
+
+- Corrected the F1 Apply path so a healthy Direct-Vulkan process does not
+  mistake its own active clean-session marker for evidence of a previous
+  interrupted session.
+- Changed genuinely stale Direct markers from a permanent lockout into an
+  explicit Yes/No retry. Accepting removes the stale marker and restarts into
+  Direct presentation; declining retains Safe presentation.
+- Added a clear writable-folder error if the stale marker cannot be removed.
+- Added developer-only persisted Time Attack driving-path capture/playback for
+  bounded route QA. The binary format is validated; capture data is private,
+  user-derived test input and none is included in Git or the demo package.
+- Corrected learned-path recovery timing to use the live 60 Hz player-control
+  clock rather than the completed capture's final tick.
+- Updated the launcher's own product identity to v2456 so its GitHub check
+  cannot offer the currently installed release as a newer update.
+- Passed compilation, synthetic capture/playback, route-parser,
+  controller/music, restart/shutdown, link-freshness, and standalone
+  no-firmware checks. Live acceptance of the F1 Direct-retry flow and the
+  learned path beyond the existing 663 m stall remain open.
+- Re-audited a 17-file Windows x64 public ZIP containing no game data, BIOS,
+  PIC, extracted assets, cards, custom music, logs, captures, learned paths,
+  generated guest translations, or private host paths.
+
 ## v2454-card-reinsert-updater — 2026-09-01
 
 - Separated an ejected card's front-sensor/removal state from the next

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of *Initial D Arcade Stage 3* (GDS-0033) for modern Windows PCs.
 > not include game data, a BIOS, card saves, custom music, logs, or extracted
 > assets. You must provide your own legally obtained matching game files.
 
-[**Download Public Early Demo v2454 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2454-card-reinsert-updater)
+[**Download Public Early Demo v2456 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2456-direct-vulkan-retry)
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
@@ -29,8 +29,8 @@ PIC only to verify and locally extract the data required by the recompilation.
 
 ## Quick start
 
-1. Download and extract `Public Early Demo v2454.zip` from the
-   [v2454 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2454-card-reinsert-updater).
+1. Download and extract `Public.Early.Demo.v2456.zip` from the
+   [v2456 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2456-direct-vulkan-retry).
 2. Place your own matching files in the included `game files` folder:
    - `gds-0033.chd`
    - `317-0384-com.pic`
@@ -42,9 +42,9 @@ Python is not required. Allow roughly 1.3 GB of temporary free space during
 first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 
 Public ZIP SHA-256:
-`041CBA8943BF7DF43F61B9843FC81C93C5C8107E2FAAF16E16CFA45B69B317AD`
+`F5A101272EC7B8EFB04C89EAD4ADBCC2F84CD5CB74C12DE2B94C7C9109398B88`
 
-## Current integration progress (v2454 WIP and public early demo)
+## Current integration progress (v2456 WIP and public early demo)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -89,8 +89,9 @@ Public ZIP SHA-256:
   upload waits; no queue-idle, device-idle, or infinite fence wait remains.
 - Direct Vulkan presentation now bypasses the CPU/GDI display copy when the
   user explicitly selects it. A clean-session marker automatically falls back
-  to Safe presentation after an interrupted Direct session. v2445 carries the
-  selected Direct/Safe choice through the Windows launcher after restart.
+  to Safe presentation after an interrupted Direct session. v2456 no longer
+  mistakes the current healthy process's own marker for an earlier crash, and
+  a genuinely stale marker offers an explicit Direct retry after restart.
 - GPU projection, ELAN lighting, depth normalization, static-geometry reuse,
   packed topology, and persistent mapped geometry/uniform streams remove the
   previous per-frame CPU staging copies.
@@ -177,6 +178,13 @@ Public ZIP SHA-256:
   log, capture, or private path. Bunta win and loss post-result runs plus a
   three-minute no-input attract run all exited cooperatively without a
   recognized crash or untranslated-runtime fault.
+- The v2456 Direct-Vulkan retry checkpoint passed compilation, a 33-case
+  restart/shutdown suite, 20 route-parser checks, 15 controller/music checks,
+  an exact synthetic learned-path round trip, link-freshness checks, and the
+  standalone no-firmware audit. The audited 17-file ZIP contains no game data,
+  BIOS, PIC, cards, music, logs, captures, private racing paths, generated guest
+  translations, or private host paths. Live acceptance of the corrected F1
+  Direct-retry flow remains pending and is not claimed by this checkpoint.
 - The earlier v2446/schema-5 checkpoint established independent three-field
   direction identity and stopped treating dry/wet condition meshes as road
   direction. The final-v2449 70/70 matrix below supersedes its mixed-build
@@ -241,8 +249,10 @@ failure, and the newest logs. Do not upload game files, extracted assets, card
 data, or copyrighted music.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
+[the v2456 public checkpoint](docs/CURRENT_CHECKPOINT_V2456_DIRECT_VULKAN_RETRY_2026-09-01.md)
+for the latest Direct-Vulkan/release facts,
 [the v2454 public checkpoint](docs/CURRENT_CHECKPOINT_V2454_CARD_REINSERT_UPDATER_2026-09-01.md)
-for the latest card/updater/release facts,
+for the preceding card/updater facts,
 [the v2445 public checkpoint](docs/CURRENT_CHECKPOINT_V2445_2026-09-01.md)
 for the preceding launcher facts,
 [the v2449 integration checkpoint](docs/CURRENT_CHECKPOINT_V2449_CINEMATIC_MASK_2026-09-01.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## Current integration checkpoint — v2453 exact rival-result renewal
+## Current integration checkpoint — v2456 Direct-Vulkan retry
 
 - Direct Vulkan presentation bypasses the Safe path's CPU/GDI display boundary
   when explicitly selected.
@@ -11,8 +11,9 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
   streams instead of per-frame CPU staging copies.
 - A compatible Safe-mode BGRA readback can be copied directly into a Win32
   32-bit DIB; diagnostics retain exact RGB24 output.
-- An interrupted Direct session leaves a marker that forces the next launch
-  back to Safe presentation.
+- An interrupted Direct session leaves a marker that returns the next launch
+  to Safe presentation. v2456 distinguishes that stale marker from the current
+  healthy process's active marker and offers an explicit Direct retry.
 - One live 2560x1080 RX 9070 XT run sustained 119.7–120.3 FPS through a heavy
   course and result transition, then exited normally and removed the marker.
 - v2441 retains immutable topology eligibility summaries for exact-matched
@@ -35,14 +36,19 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
   Evo 6, Keisuke rematch, Kyoko, Ryosuke rematch, Sakamoto, Smiley, Sudo
   rematch, and Wataru. This is 9/32 current-build profiles; the historical
   32/32 accepted ledger is intentionally not promoted to a same-build claim.
+- Developer-only persisted Time Attack path capture/playback now has a
+  validated binary format and live-control-clock recovery policy. No learned
+  input data is published. Live validation past the existing 663 m route stall
+  remains an open QA gate.
 
 Checkpoint result: the newest Direct performance and attract runs are
 host-clean, the cinematic widescreen defect is regression-protected, the
 entire route-state matrix has exact-v2449 movement proof, and nine natural
-rival results now have strict exact-v2453 evidence. Full-race, cross-driver,
-car/opponent, campaign, persistence, and visual stress are still required.
+rival results now have strict exact-v2453 evidence. v2456 corrects the Direct
+retry policy offline, but live acceptance is still required. Full-race,
+cross-driver, car/opponent, campaign, persistence, and visual stress remain.
 
-## Published checkpoint — v2445 public early demo
+## Published checkpoint — v2456 public early demo
 
 - A Windows x64 package now verifies matching user-owned CHD/PIC inputs,
   extracts required data locally, and launches the BIOS-free static-AOT path
@@ -60,9 +66,11 @@ car/opponent, campaign, persistence, and visual stress are still required.
   product has no unbounded Vulkan queue-idle, device-idle, or fence wait.
 - The product rejects concurrent instances, Windows QA shutdown is
   cooperative-only, and route-only coverage defaults to no Vulkan WSI.
-- The saved Direct/Safe Vulkan presentation choice now survives launcher
-  restart; the public ZIP was re-audited with no game data, firmware, cards,
-  music, captures, generated guest code, or private paths.
+- The saved Direct/Safe Vulkan presentation choice survives launcher restart;
+  a current Direct session is no longer falsely locked out, and a stale marker
+  can be retried explicitly. The public ZIP was re-audited with no game data,
+  firmware, cards, music, captures, learned paths, generated guest code, or
+  private paths.
 
 Checkpoint result: suitable for cautious public testing at the default 60 FPS,
 not release-ready.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2454 WIP
-Public checkpoint: v2454 Windows x64 early-demo prerelease
+Integration checkpoint: v2456 WIP
+Public checkpoint: v2456 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
 
@@ -18,11 +18,27 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; the product's 44.1 kHz stereo PCM format opens on the preferred Windows endpoint; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/eject/removal/reinsert/reload; selected managed cards use a move-safe path under the local `card data` folder. The post-Bunta result path now waits for the required physical-removal status before queuing the saved card for the next prompt | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
 | Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2448 2560x1080 Akagi run held 120.0 FPS minimum/average across 21 moving-race samples, produced 240 distinct frames per two-second sample, and added zero repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
-| Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. One sustained v2440 live Direct run completed exit code 0 and removed its session marker | Repeated live close/restart stress across more GPUs/drivers remains open |
-| Distribution | The v2454 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified updates before launch | Clean-machine coverage is limited and the release remains unfinished |
+| Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. v2456 distinguishes the active process's own Direct marker from a stale interrupted-session marker and offers an explicit retry for the latter | Repeated live close/restart stress across more GPUs/drivers and live acceptance of the new retry prompt remain open |
+| Distribution | The v2456 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified updates before launch | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
 
+- v2456 native executable SHA-256:
+  `767AA71205F9C45C722FB4857516A1B0AEC822CC64F8FCE8F865E4243E82B8EC`.
+  Compilation, 33 restart/shutdown policies, 20 route-parser policies, 15
+  controller/music policies, an exact synthetic learned-path round trip, link
+  freshness, and the standalone no-firmware audit pass. The audit reports zero
+  firmware callbacks, objects, input contracts, or cached translations.
+- v2456 public ZIP SHA-256:
+  `F5A101272EC7B8EFB04C89EAD4ADBCC2F84CD5CB74C12DE2B94C7C9109398B88`;
+  audited size is 18,577,242 bytes. Its 17 entries contain no game data, BIOS,
+  PIC, cards, custom music, logs, captures, learned racing paths, generated
+  guest code, or private paths.
+- The v2456 Direct-session policy does not interpret the current healthy
+  process's marker as a prior crash. A genuinely stale marker presents a
+  Yes/No Direct retry; accepting clears the stale marker before restart, while
+  declining keeps Safe presentation. The corrected UI path has not yet had a
+  live end-to-end acceptance run, so that result is not claimed.
 - v2454 native executable SHA-256:
   `4E9D607E2F475E38AF8A40BAF6DAE4D8F79CB62C57172D1BB0D1E6FCA065C013`.
   Its exact card-device suite covers 27 transactions, including an early

--- a/docs/CURRENT_CHECKPOINT_V2456_DIRECT_VULKAN_RETRY_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2456_DIRECT_VULKAN_RETRY_2026-09-01.md
@@ -1,0 +1,81 @@
+# v2456 Direct-Vulkan retry checkpoint — 2026-09-01
+
+## Scope
+
+This public early-demo checkpoint corrects Direct-Vulkan clean-session marker
+handling and carries forward the v2454 card-reinsert and verified-updater work.
+It remains unfinished playtest software. Safe Vulkan at 60 FPS remains the
+default.
+
+The runtime is the BIOS-free static-AOT NAOMI 2 path. It contains no SH-4
+interpreter or JIT fallback and does not boot through a NAOMI 2 BIOS.
+
+## Direct-Vulkan correction
+
+The runtime arms a marker while Direct Vulkan is active so an interrupted
+session can return the next launch to Safe presentation. The earlier F1 Apply
+path could see the marker created by its own current process and incorrectly
+treat that healthy session as a previous crash.
+
+v2456 distinguishes the current process's armed marker from a marker inherited
+from an earlier interrupted session. A genuinely stale marker now presents an
+explicit choice:
+
+- **Yes** removes the stale marker and restarts into Direct Vulkan.
+- **No** keeps Safe Vulkan.
+- A failed marker removal reports that the demo folder must be writable.
+
+The source/offline restart policy passes. A live end-to-end acceptance of the
+corrected F1 prompt on the packaged v2456 executable is still pending and is
+not claimed here.
+
+## Developer-only route QA
+
+The private integration adds persisted Time Attack player-path capture and
+playback to reproduce long route-specific behavior through ordinary 60 Hz
+player control. Its binary format and synthetic round trip pass, and playback
+recovery now advances from the current live control tick rather than the
+capture's final tick.
+
+This is QA support, not shipped game content. No captured path is included in
+Git or the public package. A live retest beyond the previously observed 663 m
+stall remains open.
+
+## Verification
+
+- Native executable SHA-256:
+  `767AA71205F9C45C722FB4857516A1B0AEC822CC64F8FCE8F865E4243E82B8EC`
+- Compilation: pass.
+- Exact synthetic path-cache capture/playback test: pass.
+- Route-matrix parser: 20 checks pass.
+- Controller/music policy: 15 checks pass.
+- Restart/shutdown policy: 33 checks pass.
+- Presenter-owner link freshness: pass.
+- Standalone no-firmware audit: zero firmware callbacks, firmware AOT objects,
+  firmware input contracts, and cached firmware translations.
+
+These are focused engineering results, not whole-game completion evidence.
+
+## Public package audit
+
+- Asset: `Public.Early.Demo.v2456.zip`
+- SHA-256:
+  `F5A101272EC7B8EFB04C89EAD4ADBCC2F84CD5CB74C12DE2B94C7C9109398B88`
+- Size: 18,577,242 bytes.
+- Entries: 17 files.
+- Embedded executable hash matches the native executable hash above.
+- `PRODUCT_VERSION.txt` contains `2456`.
+
+The package contains no CHD, PIC, BIOS, game data, extracted assets, card
+saves, custom music, logs, captures, learned paths, generated guest translation
+units, credentials, or private host paths. Users must provide their own legally
+obtained matching game inputs. Python is not required.
+
+## Open acceptance work
+
+- Live acceptance of the corrected F1 Direct-Vulkan retry flow.
+- Live learned-path playback beyond the existing 663 m Time Attack stall.
+- Broader controller, wheel, audio, Vulkan-driver, restart, route, campaign,
+  replay, card-error, visual, and higher-refresh coverage.
+- Completion of remaining untranslated/indirect paths and removal of
+  compatibility-only diagnostics.

--- a/docs/PUBLIC_PACKAGE.md
+++ b/docs/PUBLIC_PACKAGE.md
@@ -25,7 +25,7 @@
 The Git source package documents and tests the engineering work but cannot boot
 the game by itself. The separate Windows prerelease includes the native runtime
 and local setup tools, but still contains no user-owned game inputs. That
-boundary is intentional. The v2454 public ZIP adds `PRODUCT_VERSION.txt` and
-the two updater helpers; it contains 17 audited files in total. Update packages
+boundary is intentional. The v2456 public ZIP retains `PRODUCT_VERSION.txt`
+and the two updater helpers; it contains 17 audited files in total. Update packages
 preserve `game files`, `card data`, `custom music`, `logs`, the user settings
 INI, and the automatic-update preference.

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -22,13 +22,15 @@ decoder/renderer snapshots refer to support
 headers in the private integration tree and are included for review, not as a
 claim that this repository is a complete runtime.
 
-The private v2449 integration tree has advanced beyond these selected snapshots
+The private v2456 integration tree has advanced beyond these selected snapshots
 with targeted menu-to-race/result/save execution, corrected HUD and mirror
 projection, additional PVR list features, native AICA/Maple/JVS/card tests,
 persistent renderer workers, Vulkan pipeline prewarming, fixed 60 Hz retained
 presentation during guest loads, distinct 120 Hz presentation accounting,
 exact authored-cinematic-matte widescreen handling, and asset-lineage
-validation. These components will be moved into this public tree only when they
+validation. It also includes developer-only persisted Time Attack input-path
+QA and the corrected Direct-Vulkan stale-session retry policy; no learned path
+data is published. These components will be moved into this public tree only when they
 can be separated cleanly from generated game code and private captures without
 weakening the legal boundary.
 

--- a/tests/test_launcher_policy.py
+++ b/tests/test_launcher_policy.py
@@ -67,7 +67,7 @@ class LauncherPolicyTests(unittest.TestCase):
         update_call = LAUNCHER.index("Invoke-Idas3UpdateCheck")
         setup_call = LAUNCHER.index("function Find-GameInputFile")
         self.assertLess(update_call, setup_call)
-        self.assertIn("$ProductVersion = 2454", LAUNCHER)
+        self.assertIn("$ProductVersion = 2456", LAUNCHER)
         self.assertIn("[switch]$SkipUpdateCheck", LAUNCHER)
 
     def test_update_prompt_includes_version_date_and_automatic_choice(self):

--- a/tools/windows/Play Demo.ps1
+++ b/tools/windows/Play Demo.ps1
@@ -58,7 +58,7 @@ trap {
 $handoffRoot = $PSScriptRoot
 $buildRoot = $PSScriptRoot
 $logRoot = Join-Path $PSScriptRoot 'logs'
-$ProductVersion = 2454
+$ProductVersion = 2456
 $currentExecutable = Join-Path $buildRoot 'demo.exe'
 $exe = if ($Exe) {
     (Resolve-Path -LiteralPath $Exe).Path


### PR DESCRIPTION
Publishes the v2456 Windows x64 early-demo checkpoint.

- Corrects the Direct-Vulkan active-marker false lock and adds an explicit stale-session retry.
- Adds developer-only learned Time Attack path QA without publishing captured input data.
- Updates the launcher product identity to 2456 so update checks do not offer the installed release again.
- Documents the focused verification results and outstanding live acceptance work.
- Keeps game data, BIOS/PIC/CHD inputs, cards, music, logs, captures, generated guest translations, and private paths out of Git.

Public checks and the audited 17-file package pass locally.