### PR TITLE
Publish v2457 Direct-authoritative checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v2457-direct-authoritative — 2026-09-01
+
+- Made a saved Direct Vulkan selection authoritative. A stale diagnostic
+  session marker is cleared automatically when possible and no longer opens a
+  retry prompt or changes the renderer to Safe.
+- Continued with Direct if session-marker maintenance is unavailable instead
+  of silently overriding the user's renderer choice. Safe remains the
+  first-run default and is still available when explicitly selected.
+- Passed compilation, 34 restart/shutdown policies, 20 route-parser policies,
+  15 controller/music policies, synthetic path round-trip, link-freshness, and
+  standalone no-firmware checks. No live Direct-renderer run is claimed for
+  this checkpoint.
+- Completed an isolated live-GitHub updater acceptance: it selected the
+  expected newer release, required the published SHA-256, installed it while
+  preserving user-owned folders and settings, and did not offer the installed
+  current version again. The game was not launched during this test.
+- Updated the launcher's product identity to v2457 and re-audited a 17-file
+  Windows x64 public ZIP containing no game data, BIOS, PIC, extracted assets,
+  cards, custom music, logs, captures, learned paths, generated guest
+  translations, or private host paths.
+
 ## v2456-direct-vulkan-retry — 2026-09-01
 
 - Corrected the F1 Apply path so a healthy Direct-Vulkan process does not

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of *Initial D Arcade Stage 3* (GDS-0033) for modern Windows PCs.
 > not include game data, a BIOS, card saves, custom music, logs, or extracted
 > assets. You must provide your own legally obtained matching game files.
 
-[**Download Public Early Demo v2456 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2456-direct-vulkan-retry)
+[**Download Public Early Demo v2457 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2457-direct-authoritative)
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
@@ -29,8 +29,8 @@ PIC only to verify and locally extract the data required by the recompilation.
 
 ## Quick start
 
-1. Download and extract `Public.Early.Demo.v2456.zip` from the
-   [v2456 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2456-direct-vulkan-retry).
+1. Download and extract `Public.Early.Demo.v2457.zip` from the
+   [v2457 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2457-direct-authoritative).
 2. Place your own matching files in the included `game files` folder:
    - `gds-0033.chd`
    - `317-0384-com.pic`
@@ -42,9 +42,9 @@ Python is not required. Allow roughly 1.3 GB of temporary free space during
 first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 
 Public ZIP SHA-256:
-`F5A101272EC7B8EFB04C89EAD4ADBCC2F84CD5CB74C12DE2B94C7C9109398B88`
+`5E6785CAC48C1BFEA6509E0AAADF28C9B2F1639969806A85093D103081346A2C`
 
-## Current integration progress (v2456 WIP and public early demo)
+## Current integration progress (v2457 WIP and public early demo)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -87,11 +87,10 @@ Public ZIP SHA-256:
   renderer drain as a normal close.
 - Bounded Vulkan acquire, graphics-fence, presentation-fence, and startup
   upload waits; no queue-idle, device-idle, or infinite fence wait remains.
-- Direct Vulkan presentation now bypasses the CPU/GDI display copy when the
-  user explicitly selects it. A clean-session marker automatically falls back
-  to Safe presentation after an interrupted Direct session. v2456 no longer
-  mistakes the current healthy process's own marker for an earlier crash, and
-  a genuinely stale marker offers an explicit Direct retry after restart.
+- Direct Vulkan presentation bypasses the CPU/GDI display copy when the user
+  selects it. v2457 treats that saved choice as authoritative: a stale or
+  unavailable diagnostic marker neither prompts nor silently changes the
+  renderer to Safe. Safe remains the first-run default and a manual option.
 - GPU projection, ELAN lighting, depth normalization, static-geometry reuse,
   packed topology, and persistent mapped geometry/uniform streams remove the
   previous per-frame CPU staging copies.
@@ -185,6 +184,14 @@ Public ZIP SHA-256:
   BIOS, PIC, cards, music, logs, captures, private racing paths, generated guest
   translations, or private host paths. Live acceptance of the corrected F1
   Direct-retry flow remains pending and is not claimed by this checkpoint.
+- The v2457 Direct-authoritative checkpoint passed compilation, a 34-case
+  restart/shutdown suite, 20 route-parser checks, 15 controller/music checks,
+  an exact synthetic learned-path round trip, link-freshness checks, and the
+  standalone no-firmware audit. A live isolated updater acceptance selected
+  v2456 from an older installation, verified GitHub's asset digest, installed
+  it, preserved user data, and confirmed that an already-current installation
+  is not offered the same update. No live Direct-renderer run is claimed for
+  v2457.
 - The earlier v2446/schema-5 checkpoint established independent three-field
   direction identity and stopped treating dry/wet condition meshes as road
   direction. The final-v2449 70/70 matrix below supersedes its mixed-build
@@ -249,8 +256,10 @@ failure, and the newest logs. Do not upload game files, extracted assets, card
 data, or copyrighted music.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
-[the v2456 public checkpoint](docs/CURRENT_CHECKPOINT_V2456_DIRECT_VULKAN_RETRY_2026-09-01.md)
+[the v2457 public checkpoint](docs/CURRENT_CHECKPOINT_V2457_DIRECT_AUTHORITATIVE_2026-09-01.md)
 for the latest Direct-Vulkan/release facts,
+[the v2456 public checkpoint](docs/CURRENT_CHECKPOINT_V2456_DIRECT_VULKAN_RETRY_2026-09-01.md)
+for the preceding Direct-Vulkan retry facts,
 [the v2454 public checkpoint](docs/CURRENT_CHECKPOINT_V2454_CARD_REINSERT_UPDATER_2026-09-01.md)
 for the preceding card/updater facts,
 [the v2445 public checkpoint](docs/CURRENT_CHECKPOINT_V2445_2026-09-01.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## Current integration checkpoint — v2456 Direct-Vulkan retry
+## Current integration checkpoint — v2457 Direct-authoritative Vulkan
 
 - Direct Vulkan presentation bypasses the Safe path's CPU/GDI display boundary
   when explicitly selected.
@@ -11,9 +11,10 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
   streams instead of per-frame CPU staging copies.
 - A compatible Safe-mode BGRA readback can be copied directly into a Win32
   32-bit DIB; diagnostics retain exact RGB24 output.
-- An interrupted Direct session leaves a marker that returns the next launch
-  to Safe presentation. v2456 distinguishes that stale marker from the current
-  healthy process's active marker and offers an explicit Direct retry.
+- A saved Direct selection is authoritative. v2457 automatically clears a
+  stale diagnostic marker when possible and proceeds with Direct even when
+  marker maintenance is unavailable; it neither prompts nor forces Safe.
+  Safe remains the first-run default and a manual selection.
 - One live 2560x1080 RX 9070 XT run sustained 119.7–120.3 FPS through a heavy
   course and result transition, then exited normally and removed the marker.
 - v2441 retains immutable topology eligibility summaries for exact-matched
@@ -44,11 +45,12 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
 Checkpoint result: the newest Direct performance and attract runs are
 host-clean, the cinematic widescreen defect is regression-protected, the
 entire route-state matrix has exact-v2449 movement proof, and nine natural
-rival results now have strict exact-v2453 evidence. v2456 corrects the Direct
-retry policy offline, but live acceptance is still required. Full-race,
+rival results now have strict exact-v2453 evidence. v2457 protects the saved
+Direct choice in offline policy tests; a live Direct-renderer acceptance run
+for this exact build is not claimed. Full-race,
 cross-driver, car/opponent, campaign, persistence, and visual stress remain.
 
-## Published checkpoint — v2456 public early demo
+## Published checkpoint — v2457 public early demo
 
 - A Windows x64 package now verifies matching user-owned CHD/PIC inputs,
   extracts required data locally, and launches the BIOS-free static-AOT path
@@ -67,10 +69,13 @@ cross-driver, car/opponent, campaign, persistence, and visual stress remain.
 - The product rejects concurrent instances, Windows QA shutdown is
   cooperative-only, and route-only coverage defaults to no Vulkan WSI.
 - The saved Direct/Safe Vulkan presentation choice survives launcher restart;
-  a current Direct session is no longer falsely locked out, and a stale marker
-  can be retried explicitly. The public ZIP was re-audited with no game data,
+  Direct is not silently replaced by Safe because of stale or unavailable
+  marker state. The public ZIP was re-audited with no game data,
   firmware, cards, music, captures, learned paths, generated guest code, or
   private paths.
+- The live updater acceptance verified release selection, GitHub's SHA-256,
+  installation, user-data preservation, and current-version suppression in an
+  isolated folder without starting the game.
 
 Checkpoint result: suitable for cautious public testing at the default 60 FPS,
 not release-ready.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2456 WIP
-Public checkpoint: v2456 Windows x64 early-demo prerelease
+Integration checkpoint: v2457 WIP
+Public checkpoint: v2457 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
 
@@ -18,27 +18,33 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | Audio | Flycast-derived AICA SGC/mailbox tests pass; the ARM7/AICA path produces sustained non-silent samples; the product's 44.1 kHz stereo PCM format opens on the preferred Windows endpoint; 13 custom music mappings follow authentic stream commands | Audible end-user acceptance and exhaustive music/voice/effect coverage remain open |
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/eject/removal/reinsert/reload; selected managed cards use a move-safe path under the local `card data` folder. The post-Bunta result path now waits for the required physical-removal status before queuing the saved card for the next prompt | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
 | Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2448 2560x1080 Akagi run held 120.0 FPS minimum/average across 21 moving-race samples, produced 240 distinct frames per two-second sample, and added zero repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
-| Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session crash lock pass source/offscreen checks. v2456 distinguishes the active process's own Direct marker from a stale interrupted-session marker and offers an explicit retry for the latter | Repeated live close/restart stress across more GPUs/drivers and live acceptance of the new retry prompt remain open |
-| Distribution | The v2456 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified updates before launch | Clean-machine coverage is limited and the release remains unfinished |
+| Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session diagnostics pass source/offscreen checks. v2457 treats a saved Direct choice as authoritative: a stale or unavailable diagnostic marker does not prompt or force Safe; Safe remains the first-run default and a manual choice | Repeated live close/restart stress across more GPUs/drivers remains open; no live Direct-renderer run is claimed for v2457 |
+| Distribution | The v2457 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified updates before launch | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
 
-- v2456 native executable SHA-256:
-  `767AA71205F9C45C722FB4857516A1B0AEC822CC64F8FCE8F865E4243E82B8EC`.
-  Compilation, 33 restart/shutdown policies, 20 route-parser policies, 15
+- v2457 native executable SHA-256:
+  `CCDF9A0C3E195C8845CBFF0D8224D07854855D47CAC9DE4452F6598BB1581F94`.
+  Compilation, 34 restart/shutdown policies, 20 route-parser policies, 15
   controller/music policies, an exact synthetic learned-path round trip, link
   freshness, and the standalone no-firmware audit pass. The audit reports zero
   firmware callbacks, objects, input contracts, or cached translations.
-- v2456 public ZIP SHA-256:
-  `F5A101272EC7B8EFB04C89EAD4ADBCC2F84CD5CB74C12DE2B94C7C9109398B88`;
-  audited size is 18,577,242 bytes. Its 17 entries contain no game data, BIOS,
+- v2457 public ZIP SHA-256:
+  `5E6785CAC48C1BFEA6509E0AAADF28C9B2F1639969806A85093D103081346A2C`;
+  audited size is 18,576,649 bytes. Its 17 entries contain no game data, BIOS,
   PIC, cards, custom music, logs, captures, learned racing paths, generated
   guest code, or private paths.
-- The v2456 Direct-session policy does not interpret the current healthy
-  process's marker as a prior crash. A genuinely stale marker presents a
-  Yes/No Direct retry; accepting clears the stale marker before restart, while
-  declining keeps Safe presentation. The corrected UI path has not yet had a
-  live end-to-end acceptance run, so that result is not claimed.
+- The v2457 Direct-session policy automatically clears a stale diagnostic
+  marker when possible and proceeds with the saved Direct choice. If marker
+  maintenance is unavailable it still proceeds with Direct; there is no
+  automatic Safe fallback or retry prompt. Safe remains the first-run default
+  and is used when selected. This policy passed source/offline checks; no live
+  Direct-renderer acceptance run is claimed for v2457.
+- A live isolated updater acceptance queried GitHub Releases, selected v2456
+  from an older installation, downloaded 18,577,242 bytes, matched GitHub's
+  published SHA-256, installed it, preserved game files/cards/music/logs/
+  settings/update preference, and confirmed that the current version is not
+  offered itself. The acceptance did not launch the game.
 - v2454 native executable SHA-256:
   `4E9D607E2F475E38AF8A40BAF6DAE4D8F79CB62C57172D1BB0D1E6FCA065C013`.
   Its exact card-device suite covers 27 transactions, including an early

--- a/docs/CURRENT_CHECKPOINT_V2457_DIRECT_AUTHORITATIVE_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2457_DIRECT_AUTHORITATIVE_2026-09-01.md
@@ -1,0 +1,47 @@
+# v2457 Direct-authoritative public checkpoint — 2026-09-01
+
+v2457 changes how the Windows runtime respects the selected Vulkan presenter.
+If Direct is saved, the runtime now uses Direct automatically. A stale
+diagnostic session marker is cleared when possible, but neither a stale marker
+nor unavailable marker maintenance opens a prompt or silently changes the
+renderer to Safe. Safe remains the first-run default and a manual F1 setting.
+
+## Verification
+
+- Native executable SHA-256:
+  `CCDF9A0C3E195C8845CBFF0D8224D07854855D47CAC9DE4452F6598BB1581F94`.
+- Compilation and the full bounded build script completed successfully.
+- Restart/shutdown policy suite: 34 passing checks.
+- Route parser: 20 passing checks.
+- Controller/music policy: 15 passing checks.
+- Synthetic developer path capture/playback round trip, translation-source
+  verification, 116-object link freshness, and the standalone no-firmware
+  audit passed.
+- The no-firmware audit reported zero firmware callbacks, firmware AOT
+  objects, firmware input contracts, and cached firmware translations.
+- A live isolated updater acceptance queried GitHub Releases, selected v2456
+  from an older installation, downloaded and verified the published asset,
+  installed it, preserved user-owned data and settings, and confirmed that a
+  current installation is not offered the same version. It did not launch the
+  game.
+
+No live Direct-renderer run was performed for v2457, so this checkpoint does
+not claim same-build GPU/driver acceptance. Earlier bounded Direct evidence is
+retained in the status ledger; broader driver and restart stress remains open.
+
+## Public package
+
+- Asset: `Public.Early.Demo.v2457.zip`
+- ZIP size: 18,576,649 bytes
+- ZIP SHA-256:
+  `5E6785CAC48C1BFEA6509E0AAADF28C9B2F1639969806A85093D103081346A2C`
+- Entries: 17
+
+The archive contains the launcher, native executable, local setup helpers,
+public defaults, version marker, updater, and documentation. It contains no
+game data, BIOS, PIC, extracted assets, cards, custom music, logs, captures,
+learned driving paths, generated guest translation bodies, or private host
+paths. Users must provide their own legally obtained matching game files.
+
+This remains unfinished early-demo software. Use the default 60 FPS mode first;
+higher-refresh presentation and whole-game coverage are still experimental.

--- a/docs/PUBLIC_PACKAGE.md
+++ b/docs/PUBLIC_PACKAGE.md
@@ -25,7 +25,7 @@
 The Git source package documents and tests the engineering work but cannot boot
 the game by itself. The separate Windows prerelease includes the native runtime
 and local setup tools, but still contains no user-owned game inputs. That
-boundary is intentional. The v2456 public ZIP retains `PRODUCT_VERSION.txt`
+boundary is intentional. The v2457 public ZIP retains `PRODUCT_VERSION.txt`
 and the two updater helpers; it contains 17 audited files in total. Update packages
 preserve `game files`, `card data`, `custom music`, `logs`, the user settings
 INI, and the automatic-update preference.

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -22,14 +22,15 @@ decoder/renderer snapshots refer to support
 headers in the private integration tree and are included for review, not as a
 claim that this repository is a complete runtime.
 
-The private v2456 integration tree has advanced beyond these selected snapshots
+The private v2457 integration tree has advanced beyond these selected snapshots
 with targeted menu-to-race/result/save execution, corrected HUD and mirror
 projection, additional PVR list features, native AICA/Maple/JVS/card tests,
 persistent renderer workers, Vulkan pipeline prewarming, fixed 60 Hz retained
 presentation during guest loads, distinct 120 Hz presentation accounting,
 exact authored-cinematic-matte widescreen handling, and asset-lineage
 validation. It also includes developer-only persisted Time Attack input-path
-QA and the corrected Direct-Vulkan stale-session retry policy; no learned path
+QA and a Direct-authoritative renderer policy that never silently changes a
+saved Direct choice to Safe because of diagnostic marker state; no learned path
 data is published. These components will be moved into this public tree only when they
 can be separated cleanly from generated game code and private captures without
 weakening the legal boundary.

--- a/tests/test_launcher_policy.py
+++ b/tests/test_launcher_policy.py
@@ -67,7 +67,7 @@ class LauncherPolicyTests(unittest.TestCase):
         update_call = LAUNCHER.index("Invoke-Idas3UpdateCheck")
         setup_call = LAUNCHER.index("function Find-GameInputFile")
         self.assertLess(update_call, setup_call)
-        self.assertIn("$ProductVersion = 2456", LAUNCHER)
+        self.assertIn("$ProductVersion = 2457", LAUNCHER)
         self.assertIn("[switch]$SkipUpdateCheck", LAUNCHER)
 
     def test_update_prompt_includes_version_date_and_automatic_choice(self):

--- a/tools/windows/Play Demo.ps1
+++ b/tools/windows/Play Demo.ps1
@@ -58,7 +58,7 @@ trap {
 $handoffRoot = $PSScriptRoot
 $buildRoot = $PSScriptRoot
 $logRoot = Join-Path $PSScriptRoot 'logs'
-$ProductVersion = 2456
+$ProductVersion = 2457
 $currentExecutable = Join-Path $buildRoot 'demo.exe'
 $exe = if ($Exe) {
     (Resolve-Path -LiteralPath $Exe).Path


### PR DESCRIPTION
## Summary
- respect a saved Direct Vulkan selection automatically without stale-marker prompts or Safe fallback
- keep Safe as the first-run default and an explicit manual choice
- publish the v2457 launcher identity, evidence ledger, changelog, roadmap, and package hash
- document the isolated live-GitHub updater acceptance and its user-data preservation

## Verification
- 17 public Python tests pass
- Windows updater tests pass
- moved-launcher test passes without launching the game
- private v2457 build: 34 restart/shutdown, 20 route-parser, 15 controller/music, path round-trip, link-freshness, and no-firmware checks pass
- audited 17-entry ZIP SHA-256: 5E6785CAC48C1BFEA6509E0AAADF28C9B2F1639969806A85093D103081346A2C

No live Direct-renderer run is claimed for v2457. The archive contains no game data or other private/user-owned content.