### PR TITLE
Publish v2458 merged updater and product naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v2458-merged-update-naming — 2026-09-01
+
+- Changed fresh archives to contain one top-level folder named
+  `Initial D Arcade Stage 3 Recompiled` and renamed the native helper to
+  `Initial D Arcade Stage 3 Recompiled Runtime.exe`. The root entry point
+  remains `Initial D Arcade Stage 3 Recompiled.exe`.
+- Made the update contract explicitly merge-based: add new product files,
+  replace versioned product files, preserve game files/cards/music/logs/
+  settings/update preference and unrelated destination-only files, and roll
+  back replaced or created product files after failure.
+- Added one v2458-only byte-identical `demo.exe` compatibility copy so the
+  updater already installed by v2457 can accept the renamed layout. The new
+  installer/launcher removes it only when its SHA-256 equals the canonical
+  runtime; a modified or unrelated file is preserved.
+- Passed the real transition with the exact updater and installer shipped in
+  v2457, plus current installer, nested-folder, rollback, merge-preservation,
+  and launcher migration checks. None of these tests launched the game.
+- Corrected learned Time Attack path control so a spatially nearby future
+  switchback cannot override the ordered cursor. A synthetic parallel-road
+  regression reproduces the Akina 663 m failure shape and now passes.
+- Passed compilation, 34 restart/shutdown, 20 route-parser, 15
+  controller/music, link-freshness, translation-source, and standalone
+  no-firmware checks. A live v2458 race run is not claimed by this checkpoint.
+
 ## v2457-direct-authoritative — 2026-09-01
 
 - Made a saved Direct Vulkan selection authoritative. A stale diagnostic

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of *Initial D Arcade Stage 3* (GDS-0033) for modern Windows PCs.
 > not include game data, a BIOS, card saves, custom music, logs, or extracted
 > assets. You must provide your own legally obtained matching game files.
 
-[**Download Public Early Demo v2457 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2457-direct-authoritative)
+[**Download Public Early Demo v2458 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2458-merged-update-naming)
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
@@ -29,8 +29,8 @@ PIC only to verify and locally extract the data required by the recompilation.
 
 ## Quick start
 
-1. Download and extract `Public.Early.Demo.v2457.zip` from the
-   [v2457 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2457-direct-authoritative).
+1. Download and extract `Initial.D.Arcade.Stage.3.Recompiled.v2458.zip` from
+   the [v2458 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2458-merged-update-naming).
 2. Place your own matching files in the included `game files` folder:
    - `gds-0033.chd`
    - `317-0384-com.pic`
@@ -42,9 +42,9 @@ Python is not required. Allow roughly 1.3 GB of temporary free space during
 first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 
 Public ZIP SHA-256:
-`5E6785CAC48C1BFEA6509E0AAADF28C9B2F1639969806A85093D103081346A2C`
+`D2DA3CFA1113E9DDA7DE88C224C4E92DC4E73540C4F44868FBB10E4A6B89CD0F`
 
-## Current integration progress (v2457 WIP and public early demo)
+## Current integration progress (v2458 WIP and public early demo)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -78,6 +78,12 @@ Public ZIP SHA-256:
   checkbox enables verified automatic installs on future launches. Updates
   preserve game files, cards, music, logs, and user settings and roll back if
   installation fails.
+- v2458 archives extract into one `Initial D Arcade Stage 3 Recompiled`
+  folder. Updates merge into the existing installation: new product files are
+  added, versioned product files are replaced, and destination-only files plus
+  user data remain untouched. The main entry point is
+  `Initial D Arcade Stage 3 Recompiled.exe`; the native helper is now
+  `Initial D Arcade Stage 3 Recompiled Runtime.exe`.
 - A self-contained, Python-free setup and integrity checker for user-owned
   inputs.
 - Cooperative renderer shutdown: the program stops new Vulkan presentation,
@@ -192,6 +198,13 @@ Public ZIP SHA-256:
   it, preserved user data, and confirmed that an already-current installation
   is not offered the same update. No live Direct-renderer run is claimed for
   v2457.
+- The v2458 merge/naming checkpoint passed the same complete private build
+  suite plus a parallel-switchback learned-path regression. The actual archive
+  passed isolated new-installer acceptance and an exact v2457-shipped-updater
+  transition: both found the nested product folder, preserved user data and
+  unrelated files, selected the renamed runtime, retired only the
+  byte-identical legacy name, and launched no game process. A live v2458 race
+  run is not claimed by this packaging checkpoint.
 - The earlier v2446/schema-5 checkpoint established independent three-field
   direction identity and stopped treating dry/wet condition meshes as road
   direction. The final-v2449 70/70 matrix below supersedes its mixed-build
@@ -256,8 +269,10 @@ failure, and the newest logs. Do not upload game files, extracted assets, card
 data, or copyrighted music.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
+[the v2458 public checkpoint](docs/CURRENT_CHECKPOINT_V2458_MERGED_UPDATE_NAMING_2026-09-01.md)
+for the latest updater, naming, and package facts,
 [the v2457 public checkpoint](docs/CURRENT_CHECKPOINT_V2457_DIRECT_AUTHORITATIVE_2026-09-01.md)
-for the latest Direct-Vulkan/release facts,
+for the preceding Direct-Vulkan/release facts,
 [the v2456 public checkpoint](docs/CURRENT_CHECKPOINT_V2456_DIRECT_VULKAN_RETRY_2026-09-01.md)
 for the preceding Direct-Vulkan retry facts,
 [the v2454 public checkpoint](docs/CURRENT_CHECKPOINT_V2454_CARD_REINSERT_UPDATER_2026-09-01.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## Current integration checkpoint — v2457 Direct-authoritative Vulkan
+## Current integration checkpoint — v2458 ordered path and merged updates
 
 - Direct Vulkan presentation bypasses the Safe path's CPU/GDI display boundary
   when explicitly selected.
@@ -39,18 +39,19 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
   32/32 accepted ledger is intentionally not promoted to a same-build claim.
 - Developer-only persisted Time Attack path capture/playback now has a
   validated binary format and live-control-clock recovery policy. No learned
-  input data is published. Live validation past the existing 663 m route stall
-  remains an open QA gate.
+  input data is published. v2458 prevents a later spatially adjacent
+  switchback from overriding the ordered controller; live validation past the
+  existing 663 m route stall remains an open QA gate.
 
 Checkpoint result: the newest Direct performance and attract runs are
 host-clean, the cinematic widescreen defect is regression-protected, the
 entire route-state matrix has exact-v2449 movement proof, and nine natural
-rival results now have strict exact-v2453 evidence. v2457 protects the saved
+rival results now have strict exact-v2453 evidence. v2458 retains the saved
 Direct choice in offline policy tests; a live Direct-renderer acceptance run
 for this exact build is not claimed. Full-race,
 cross-driver, car/opponent, campaign, persistence, and visual stress remain.
 
-## Published checkpoint — v2457 public early demo
+## Published checkpoint — v2458 public early demo
 
 - A Windows x64 package now verifies matching user-owned CHD/PIC inputs,
   extracts required data locally, and launches the BIOS-free static-AOT path
@@ -76,6 +77,10 @@ cross-driver, car/opponent, campaign, persistence, and visual stress remain.
 - The live updater acceptance verified release selection, GitHub's SHA-256,
   installation, user-data preservation, and current-version suppression in an
   isolated folder without starting the game.
+- The requested folder/main/runtime names and merge semantics pass against the
+  real v2458 archive. An additional acceptance used the exact v2457-shipped
+  updater and installer, proving existing users can cross the naming change
+  while keeping user and destination-only files.
 
 Checkpoint result: suitable for cautious public testing at the default 60 FPS,
 not release-ready.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2457 WIP
-Public checkpoint: v2457 Windows x64 early-demo prerelease
+Integration checkpoint: v2458 WIP
+Public checkpoint: v2458 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
 
@@ -19,10 +19,29 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/eject/removal/reinsert/reload; selected managed cards use a move-safe path under the local `card data` folder. The post-Bunta result path now waits for the required physical-removal status before queuing the saved card for the next prompt | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
 | Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2448 2560x1080 Akagi run held 120.0 FPS minimum/average across 21 moving-race samples, produced 240 distinct frames per two-second sample, and added zero repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
 | Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session diagnostics pass source/offscreen checks. v2457 treats a saved Direct choice as authoritative: a stale or unavailable diagnostic marker does not prompt or force Safe; Safe remains the first-run default and a manual choice | Repeated live close/restart stress across more GPUs/drivers remains open; no live Direct-renderer run is claimed for v2457 |
-| Distribution | The v2457 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified updates before launch | Clean-machine coverage is limited and the release remains unfinished |
+| Distribution | The v2458 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified merge updates. The archive has one canonically named top-level folder; the main executable and native runtime have stable product names | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
 
+- v2458 native executable SHA-256:
+  `5636197D7CA5D3DEDEAA2FA7F016A2C6899516D5C8D30A74AD150636E53C49A2`.
+  Compilation, the ordered-vs-spatial-switchback regression, 34
+  restart/shutdown policies, 20 route-parser policies, 15 controller/music
+  policies, link freshness, and the standalone no-firmware audit pass. No live
+  v2458 race acceptance is claimed by this package checkpoint.
+- v2458 public ZIP SHA-256:
+  `D2DA3CFA1113E9DDA7DE88C224C4E92DC4E73540C4F44868FBB10E4A6B89CD0F`;
+  audited size is 23,812,401 bytes. Its 18 entries include one byte-identical
+  `demo.exe` transition copy required by the updater already shipped in v2457.
+  On first v2458 launch it is retired only if it matches the canonical runtime.
+  No game data, BIOS, PIC, cards, music, logs, captures, learned paths,
+  generated guest code, or private paths are present.
+- The actual v2458 archive passed two isolated no-game-launch acceptances. The
+  current installer merged files, preserved protected and destination-only
+  data, migrated the name, and verified the runtime hash. Separately, the exact
+  updater and installer shipped in v2457 located the nested
+  `Initial D Arcade Stage 3 Recompiled` folder, installed v2458, preserved user
+  data, and handed off to the renamed runtime. Both left zero game processes.
 - v2457 native executable SHA-256:
   `CCDF9A0C3E195C8845CBFF0D8224D07854855D47CAC9DE4452F6598BB1581F94`.
   Compilation, 34 restart/shutdown policies, 20 route-parser policies, 15

--- a/docs/CURRENT_CHECKPOINT_V2458_MERGED_UPDATE_NAMING_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2458_MERGED_UPDATE_NAMING_2026-09-01.md
@@ -1,0 +1,57 @@
+# v2458 merged-update and product-naming checkpoint — 2026-09-01
+
+v2458 standardizes the downloadable layout and verifies the update transition
+from the already-published v2457 build.
+
+## Names and merge behavior
+
+- Archive: `Initial.D.Arcade.Stage.3.Recompiled.v2458.zip`
+- Top-level folder: `Initial D Arcade Stage 3 Recompiled`
+- Main entry point: `Initial D Arcade Stage 3 Recompiled.exe`
+- Native helper: `Initial D Arcade Stage 3 Recompiled Runtime.exe`
+
+The installer merges the verified package into the existing product folder.
+It adds new product files and replaces versioned product files while preserving
+`game files`, `card data`, `custom music`, `logs`, user settings, the automatic
+update preference, and unrelated destination-only files. A failed install
+restores overwritten files and removes product files created by the failed
+attempt.
+
+The v2458 archive includes one byte-identical `demo.exe` compatibility copy.
+This is required because the updater already installed by v2457 validates that
+legacy name before it can install the new scripts. After the transition, the
+new installer/launcher removes the legacy file only if its SHA-256 equals the
+canonical runtime; any modified or unrelated file is kept. Future packages can
+drop the compatibility copy after the v2457 transition window.
+
+## Accepted evidence
+
+- Native executable SHA-256:
+  `5636197D7CA5D3DEDEAA2FA7F016A2C6899516D5C8D30A74AD150636E53C49A2`
+- ZIP SHA-256:
+  `D2DA3CFA1113E9DDA7DE88C224C4E92DC4E73540C4F44868FBB10E4A6B89CD0F`
+- ZIP size: 23,812,401 bytes
+- Audited files: 18
+- Public source checks: 18 passing tests
+- Private build checks: ordered-path round trip/regression, 34
+  restart/shutdown, 20 route-parser, 15 controller/music, translation-source,
+  116-object link freshness, and standalone no-firmware checks pass.
+- The actual archive passed the current installer acceptance with protected
+  and destination-only files preserved, the canonical runtime hash verified,
+  the legacy duplicate retired, and no game process launched.
+- A separate acceptance used the exact updater and installer shipped inside
+  v2457. It located the nested product folder, merged v2458, preserved user
+  data, selected the canonical runtime, completed first-launch name migration,
+  and launched no game process.
+
+The archive contains no game data, BIOS, PIC, extracted assets, cards, custom
+music, logs, captures, learned paths, generated guest translation bodies, or
+private host paths. Users provide their own legally obtained matching inputs.
+
+The learned-path correction prevents a spatially nearby future switchback from
+becoming the steering authority ahead of the ordered cursor. The exact
+parallel-switchback regression passes, but a live v2458 race past the previous
+663 m stall is not claimed by this packaging checkpoint.
+
+This remains unfinished early-demo software. Start at 60 FPS; higher-refresh
+presentation and whole-game coverage remain experimental.

--- a/docs/PUBLIC_PACKAGE.md
+++ b/docs/PUBLIC_PACKAGE.md
@@ -25,7 +25,9 @@
 The Git source package documents and tests the engineering work but cannot boot
 the game by itself. The separate Windows prerelease includes the native runtime
 and local setup tools, but still contains no user-owned game inputs. That
-boundary is intentional. The v2457 public ZIP retains `PRODUCT_VERSION.txt`
-and the two updater helpers; it contains 17 audited files in total. Update packages
+boundary is intentional. The v2458 public ZIP retains `PRODUCT_VERSION.txt`
+and the two updater helpers; it contains 18 audited files in total because one
+byte-identical legacy runtime name is required for the v2457 updater transition.
+Update packages
 preserve `game files`, `card data`, `custom music`, `logs`, the user settings
-INI, and the automatic-update preference.
+INI, the automatic-update preference, and unrelated destination-only files.

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -22,14 +22,15 @@ decoder/renderer snapshots refer to support
 headers in the private integration tree and are included for review, not as a
 claim that this repository is a complete runtime.
 
-The private v2457 integration tree has advanced beyond these selected snapshots
+The private v2458 integration tree has advanced beyond these selected snapshots
 with targeted menu-to-race/result/save execution, corrected HUD and mirror
 projection, additional PVR list features, native AICA/Maple/JVS/card tests,
 persistent renderer workers, Vulkan pipeline prewarming, fixed 60 Hz retained
 presentation during guest loads, distinct 120 Hz presentation accounting,
 exact authored-cinematic-matte widescreen handling, and asset-lineage
 validation. It also includes developer-only persisted Time Attack input-path
-QA and a Direct-authoritative renderer policy that never silently changes a
+QA, ordered learned-path controller selection across adjacent switchbacks, and
+a Direct-authoritative renderer policy that never silently changes a
 saved Direct choice to Safe because of diagnostic marker state; no learned path
 data is published. These components will be moved into this public tree only when they
 can be separated cleanly from generated game code and private captures without

--- a/tests/test_launcher_policy.py
+++ b/tests/test_launcher_policy.py
@@ -67,8 +67,18 @@ class LauncherPolicyTests(unittest.TestCase):
         update_call = LAUNCHER.index("Invoke-Idas3UpdateCheck")
         setup_call = LAUNCHER.index("function Find-GameInputFile")
         self.assertLess(update_call, setup_call)
-        self.assertIn("$ProductVersion = 2457", LAUNCHER)
+        self.assertIn("$ProductVersion = 2458", LAUNCHER)
         self.assertIn("[switch]$SkipUpdateCheck", LAUNCHER)
+
+    def test_canonical_main_and_runtime_names_are_migration_safe(self):
+        self.assertIn("Initial D Arcade Stage 3 Recompiled Runtime.exe", LAUNCHER)
+        self.assertIn("$legacyExecutable = Join-Path $buildRoot 'demo.exe'", LAUNCHER)
+        self.assertIn("$PSBoundParameters.ContainsKey('Exe')", LAUNCHER)
+        self.assertIn("if ($canonicalHash -eq $legacyHash)", LAUNCHER)
+        self.assertIn("Initial D Arcade Stage 3 Recompiled.exe", UPDATER)
+        self.assertIn("Initial D Arcade Stage 3 Recompiled Runtime.exe", UPDATER)
+        self.assertIn("Initial D Arcade Stage 3 Recompiled.exe", INSTALLER)
+        self.assertIn("Initial D Arcade Stage 3 Recompiled Runtime.exe", INSTALLER)
 
     def test_update_prompt_includes_version_date_and_automatic_choice(self):
         self.assertIn('"Update $($Update.VersionLabel) is available"', UPDATER)
@@ -88,6 +98,8 @@ class LauncherPolicyTests(unittest.TestCase):
         self.assertIn("idas3_user_settings.ini", INSTALLER)
         self.assertIn("idas3_launcher_update_settings.json", INSTALLER)
         self.assertIn("$rollback", INSTALLER)
+        self.assertIn("Merge updates never delete unknown destination files", INSTALLER)
+        self.assertIn("if ($canonicalHash -eq $legacyHash)", INSTALLER)
 
     def test_update_sources_contain_no_private_absolute_path(self):
         for source in (UPDATER, INSTALLER):

--- a/tools/qa/test_windows_launcher_relocation.ps1
+++ b/tools/qa/test_windows_launcher_relocation.ps1
@@ -28,6 +28,8 @@ try {
         -Destination (Join-Path $resolvedTestRoot 'Play Demo.ps1')
 
     foreach ($path in @(
+        (Join-Path $resolvedTestRoot `
+            'Initial D Arcade Stage 3 Recompiled Runtime.exe'),
         (Join-Path $resolvedTestRoot 'demo.exe'),
         (Join-Path $gameRoot 'idas3_main_0C020000.bin'),
         (Join-Path $gameRoot '.idas3_extraction_complete.json'))) {
@@ -61,6 +63,9 @@ function Test-Idas3GameFiles {
     if ($result.Status -ne 'READY') {
         throw "Relocated launcher did not recover to READY: $($result.Status)"
     }
+    if (Test-Path -LiteralPath (Join-Path $resolvedTestRoot 'demo.exe')) {
+        throw 'Launcher did not retire the byte-identical legacy runtime.'
+    }
     $calls = @(Get-Content -LiteralPath $tracePath)
     if ($calls.Count -ne 2 -or $calls[0] -ne 'fast' -or
         $calls[1] -ne 'full') {
@@ -71,6 +76,7 @@ function Test-Idas3GameFiles {
         Status = 'PASS'
         RelocatedBuild = $true
         IntegritySequence = $calls -join ' -> '
+        LegacyRuntimeMigrated = $true
         GameProcessStarted = $false
     }
 } finally {

--- a/tools/qa/test_windows_updater.ps1
+++ b/tools/qa/test_windows_updater.ps1
@@ -1,6 +1,9 @@
 $ErrorActionPreference = 'Stop'
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 . (Join-Path $repoRoot 'tools\windows\UpdateSupport.ps1')
+$mainExecutableName = 'Initial D Arcade Stage 3 Recompiled.exe'
+$runtimeExecutableName = 'Initial D Arcade Stage 3 Recompiled Runtime.exe'
+$productFolderName = 'Initial D Arcade Stage 3 Recompiled'
 
 function Assert-True {
     param([bool]$Condition, [string]$Message)
@@ -10,12 +13,12 @@ function Assert-True {
 $newRelease = [pscustomobject]@{
     draft = $false
     prerelease = $true
-    tag_name = 'v2455-test'
-    name = 'Public Early Demo v2455'
+    tag_name = 'v2458-test'
+    name = 'Initial D Arcade Stage 3 Recompiled v2458'
     published_at = '2026-09-02T03:04:05Z'
     html_url = 'https://example.invalid/release'
     assets = @([pscustomobject]@{
-        name = 'Public.Early.Demo.v2455.zip'
+        name = 'Initial.D.Arcade.Stage.3.Recompiled.v2458.zip'
         size = 1234
         browser_download_url = 'https://example.invalid/update.zip'
         digest = 'sha256:' + ('a' * 64)
@@ -34,11 +37,11 @@ $olderRelease = [pscustomobject]@{
         digest = 'sha256:' + ('b' * 64)
     })
 }
-$available = Get-Idas3AvailableUpdate -CurrentVersion 2454 `
+$available = Get-Idas3AvailableUpdate -CurrentVersion 2457 `
     -Releases @($olderRelease, $newRelease)
-Assert-True ($available.Version -eq 2455) `
+Assert-True ($available.Version -eq 2458) `
     'release parser selects the highest newer prerelease'
-Assert-True (-not (Get-Idas3AvailableUpdate -CurrentVersion 2455 `
+Assert-True (-not (Get-Idas3AvailableUpdate -CurrentVersion 2458 `
     -Releases @($olderRelease, $newRelease))) `
     'current version does not update to itself or an older release'
 
@@ -64,24 +67,47 @@ try {
         (Join-Path $destinationRoot 'custom music'))) {
         New-Item -ItemType Directory -Path $path -Force | Out-Null
     }
-    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'PRODUCT_VERSION.txt'), '2455')
-    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'demo.exe'), 'new-demo')
+    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'PRODUCT_VERSION.txt'), '2458')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $sourceRoot $runtimeExecutableName), 'new-runtime')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $sourceRoot $mainExecutableName), 'new-main')
     [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'Play Demo.ps1'), 'new-launcher')
     [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'README.txt'), 'new-readme')
+    [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'new-product.txt'), 'new-product')
     [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'idas3_user_settings.ini'), 'bad-default')
     [System.IO.File]::WriteAllText((Join-Path $sourceRoot 'card data\player.card'), 'bad-card')
-    [System.IO.File]::WriteAllText((Join-Path $destinationRoot 'demo.exe'), 'old-demo')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $destinationRoot $runtimeExecutableName), 'old-runtime')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $destinationRoot $mainExecutableName), 'old-main')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $destinationRoot 'demo.exe'), 'new-runtime')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $destinationRoot 'user notes.txt'), 'keep-user-file')
     [System.IO.File]::WriteAllText((Join-Path $destinationRoot 'idas3_user_settings.ini'), 'user-settings')
     [System.IO.File]::WriteAllText((Join-Path $destinationRoot 'card data\player.card'), 'user-card')
 
     & (Join-Path $repoRoot 'tools\windows\Install Update.ps1') `
         -SourceRoot $sourceRoot -DestinationRoot $destinationRoot `
-        -WorkingRoot $workingRoot -ExpectedVersion 2455 `
+        -WorkingRoot $workingRoot -ExpectedVersion 2458 `
         -NoRelaunch -KeepWorkingDirectory -TestMode
-    $installedDemoPath = Join-Path $destinationRoot 'demo.exe'
-    $installedDemo = Get-Content -LiteralPath $installedDemoPath -Raw
-    Assert-True ($installedDemo -eq 'new-demo') `
+    $installedRuntimePath = Join-Path $destinationRoot $runtimeExecutableName
+    $installedRuntime = Get-Content -LiteralPath $installedRuntimePath -Raw
+    Assert-True ($installedRuntime -eq 'new-runtime') `
         'installer replaces product-controlled files'
+    Assert-True ((Get-Content -LiteralPath `
+            (Join-Path $destinationRoot $mainExecutableName) -Raw) -eq
+        'new-main') 'installer retains the canonical main executable name'
+    Assert-True (-not (Test-Path -LiteralPath `
+            (Join-Path $destinationRoot 'demo.exe'))) `
+        'installer removes a byte-identical legacy runtime name'
+    Assert-True ((Get-Content -LiteralPath `
+            (Join-Path $destinationRoot 'user notes.txt') -Raw) -eq
+        'keep-user-file') 'merge preserves destination-only files'
+    Assert-True ((Get-Content -LiteralPath `
+            (Join-Path $destinationRoot 'new-product.txt') -Raw) -eq
+        'new-product') 'merge adds new product files'
     $installedSettingsPath = Join-Path $destinationRoot 'idas3_user_settings.ini'
     $installedSettings = Get-Content -LiteralPath $installedSettingsPath -Raw
     Assert-True ($installedSettings -eq 'user-settings') `
@@ -91,6 +117,19 @@ try {
     Assert-True ($installedCard -eq 'user-card') `
         'installer preserves card data'
 
+    $modifiedWorking = Join-Path $testRoot 'modified-working'
+    New-Item -ItemType Directory -Path $modifiedWorking -Force | Out-Null
+    [System.IO.File]::WriteAllText(
+        (Join-Path $destinationRoot 'demo.exe'), 'locally-modified-runtime')
+    & (Join-Path $repoRoot 'tools\windows\Install Update.ps1') `
+        -SourceRoot $sourceRoot -DestinationRoot $destinationRoot `
+        -WorkingRoot $modifiedWorking -ExpectedVersion 2458 `
+        -NoRelaunch -KeepWorkingDirectory -TestMode
+    Assert-True ((Get-Content -LiteralPath `
+            (Join-Path $destinationRoot 'demo.exe') -Raw) -eq
+        'locally-modified-runtime') `
+        'merge preserves a non-identical legacy filename'
+
     $rollbackSource = Join-Path $testRoot 'rollback-source'
     $rollbackDestination = Join-Path $testRoot 'rollback-destination'
     $rollbackWorking = Join-Path $testRoot 'rollback-working'
@@ -99,19 +138,26 @@ try {
         New-Item -ItemType Directory -Path $path -Force | Out-Null
     }
     [System.IO.File]::WriteAllText(
-        (Join-Path $rollbackSource 'PRODUCT_VERSION.txt'), '2455')
+        (Join-Path $rollbackSource 'PRODUCT_VERSION.txt'), '2458')
     [System.IO.File]::WriteAllText(
-        (Join-Path $rollbackSource 'demo.exe'), 'new-rollback-demo')
+        (Join-Path $rollbackSource $runtimeExecutableName),
+        'new-rollback-runtime')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $rollbackSource $mainExecutableName), 'new-rollback-main')
     [System.IO.File]::WriteAllText(
         (Join-Path $rollbackSource 'Play Demo.ps1'), 'new-rollback-launcher')
     [System.IO.File]::WriteAllText(
-        (Join-Path $rollbackDestination 'demo.exe'), 'old-rollback-demo')
+        (Join-Path $rollbackDestination $runtimeExecutableName),
+        'old-rollback-runtime')
+    [System.IO.File]::WriteAllText(
+        (Join-Path $rollbackDestination $mainExecutableName),
+        'old-rollback-main')
     $rollbackFailed = $false
     try {
         & (Join-Path $repoRoot 'tools\windows\Install Update.ps1') `
             -SourceRoot $rollbackSource `
             -DestinationRoot $rollbackDestination `
-            -WorkingRoot $rollbackWorking -ExpectedVersion 2455 `
+            -WorkingRoot $rollbackWorking -ExpectedVersion 2458 `
             -NoRelaunch -KeepWorkingDirectory -TestMode `
             -TestFailAfterCopies 2
     } catch {
@@ -119,26 +165,34 @@ try {
     }
     Assert-True $rollbackFailed 'injected mid-install failure is reported'
     Assert-True ((Get-Content -LiteralPath `
-            (Join-Path $rollbackDestination 'demo.exe') -Raw) -eq
-        'old-rollback-demo') 'failed install restores replaced product file'
+            (Join-Path $rollbackDestination $runtimeExecutableName) -Raw) -eq
+        'old-rollback-runtime') 'failed install restores replaced product file'
     Assert-True (-not (Test-Path -LiteralPath `
             (Join-Path $rollbackDestination 'PRODUCT_VERSION.txt'))) `
         'failed install removes newly created product file'
 
     $zipPath = Join-Path $testRoot 'verified.zip'
+    $zipSource = Join-Path $testRoot 'zip-source'
+    $zipProductRoot = Join-Path $zipSource $productFolderName
+    New-Item -ItemType Directory -Path $zipProductRoot -Force | Out-Null
+    Copy-Item -Path (Join-Path $sourceRoot '*') `
+        -Destination $zipProductRoot -Recurse -Force
     Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::CreateFromDirectory($sourceRoot, $zipPath)
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($zipSource, $zipPath)
     $digest = 'sha256:' + (Get-FileHash -LiteralPath $zipPath `
         -Algorithm SHA256).Hash.ToLowerInvariant()
     $expanded = Expand-Idas3VerifiedUpdatePackage -ZipPath $zipPath `
-        -ExpectedDigest $digest -ExpectedVersion 2455 `
+        -ExpectedDigest $digest -ExpectedVersion 2458 `
         -ExtractRoot $extractRoot
     $expandedFull = [System.IO.Path]::GetFullPath([string]$expanded).
         TrimEnd('\', '/')
     $extractFull = [System.IO.Path]::GetFullPath($extractRoot).
         TrimEnd('\', '/')
-    Assert-True ($expandedFull -ieq $extractFull) `
-        'verified package extracts and locates its versioned product root'
+    $expectedExpanded = [System.IO.Path]::GetFullPath(
+        (Join-Path $extractRoot $productFolderName)).TrimEnd('\', '/')
+    Assert-True ($expandedFull -ieq $expectedExpanded -and
+        $expandedFull -ine $extractFull) `
+        'verified package locates the canonical nested product folder'
 
     $unsafeZip = Join-Path $testRoot 'unsafe.zip'
     $unsafeExtract = Join-Path $testRoot 'unsafe-extract'
@@ -157,7 +211,7 @@ try {
         $unsafeDigest = 'sha256:' + (Get-FileHash -LiteralPath $unsafeZip `
             -Algorithm SHA256).Hash.ToLowerInvariant()
         [void](Expand-Idas3VerifiedUpdatePackage -ZipPath $unsafeZip `
-            -ExpectedDigest $unsafeDigest -ExpectedVersion 2455 `
+            -ExpectedDigest $unsafeDigest -ExpectedVersion 2458 `
             -ExtractRoot $unsafeExtract)
     } catch {
         $unsafeRejected = $_.Exception.Message -match 'Unsafe path'

--- a/tools/windows/Install Update.ps1
+++ b/tools/windows/Install Update.ps1
@@ -47,7 +47,11 @@ try {
         [int]$matches.number -ne $ExpectedVersion) {
         throw "Staged package version '$marker' does not match v$ExpectedVersion."
     }
-    foreach ($required in @('demo.exe', 'Play Demo.ps1')) {
+    $mainExecutableName = 'Initial D Arcade Stage 3 Recompiled.exe'
+    $runtimeExecutableName =
+        'Initial D Arcade Stage 3 Recompiled Runtime.exe'
+    foreach ($required in @(
+        $mainExecutableName, $runtimeExecutableName, 'Play Demo.ps1')) {
         if (-not (Test-Path -LiteralPath (Join-Path $source $required) `
                 -PathType Leaf)) {
             throw "Staged package is missing $required."
@@ -101,9 +105,31 @@ try {
             [int]$matches.number -ne $ExpectedVersion) {
             throw 'Installed version marker verification failed.'
         }
-        if (-not (Test-Path -LiteralPath (Join-Path $destination 'demo.exe') `
+        $installedRuntime = Join-Path $destination $runtimeExecutableName
+        if (-not (Test-Path -LiteralPath $installedRuntime `
                 -PathType Leaf)) {
             throw 'Installed executable verification failed.'
+        }
+
+        # Merge updates never delete unknown destination files.  The sole
+        # migration exception is the old product-controlled runtime name, and
+        # even that is removed only when it is byte-identical to the newly
+        # verified canonical runtime.  Preserve a rollback copy first.
+        $legacyRuntime = Join-Path $destination 'demo.exe'
+        if (Test-Path -LiteralPath $legacyRuntime -PathType Leaf) {
+            $canonicalHash = (Get-FileHash -LiteralPath $installedRuntime `
+                -Algorithm SHA256).Hash
+            $legacyHash = (Get-FileHash -LiteralPath $legacyRuntime `
+                -Algorithm SHA256).Hash
+            if ($canonicalHash -eq $legacyHash) {
+                $legacyBackup = Join-Path $rollback 'demo.exe'
+                if (-not (Test-Path -LiteralPath $legacyBackup `
+                        -PathType Leaf)) {
+                    Copy-Item -LiteralPath $legacyRuntime `
+                        -Destination $legacyBackup -Force
+                }
+                [System.IO.File]::Delete($legacyRuntime)
+            }
         }
     } catch {
         foreach ($backupFile in Get-ChildItem -LiteralPath $rollback -Recurse -File) {

--- a/tools/windows/Play Demo.ps1
+++ b/tools/windows/Play Demo.ps1
@@ -58,15 +58,25 @@ trap {
 $handoffRoot = $PSScriptRoot
 $buildRoot = $PSScriptRoot
 $logRoot = Join-Path $PSScriptRoot 'logs'
-$ProductVersion = 2457
-$currentExecutable = Join-Path $buildRoot 'demo.exe'
+$ProductVersion = 2458
+$canonicalRuntimeName = 'Initial D Arcade Stage 3 Recompiled Runtime.exe'
+$canonicalExecutable = Join-Path $buildRoot $canonicalRuntimeName
+$legacyExecutable = Join-Path $buildRoot 'demo.exe'
+$currentExecutable = if (Test-Path -LiteralPath $canonicalExecutable `
+        -PathType Leaf) {
+    $canonicalExecutable
+} else {
+    # Compatibility with installations created before the polished runtime
+    # name was introduced.  Verified updates install the canonical file.
+    $legacyExecutable
+}
 $exe = if ($Exe) {
     (Resolve-Path -LiteralPath $Exe).Path
 } else {
     $currentExecutable
 }
 
-# A launcher-side updater can replace the product before demo.exe starts and
+# A launcher-side updater can replace the product before the native runtime starts and
 # therefore does not need to modify a running game process. Source-tree tests
 # keep UpdateSupport beside this file; packaged builds place it under tools.
 if (-not $ValidateOnly) {
@@ -84,6 +94,27 @@ if (-not $ValidateOnly) {
             # when necessary, installs in place, then relaunches once.
             return
         }
+    }
+}
+
+# v2458 is a transition package: it includes the old runtime name so v2457's
+# already-installed updater can verify the archive, plus the canonical name
+# used from this launch onward.  Remove only a byte-identical legacy duplicate;
+# an unrelated or locally modified demo.exe is deliberately preserved.
+if (-not $PSBoundParameters.ContainsKey('Exe') -and
+    (Test-Path -LiteralPath $canonicalExecutable -PathType Leaf) -and
+    (Test-Path -LiteralPath $legacyExecutable -PathType Leaf)) {
+    try {
+        $canonicalHash = (Get-FileHash -LiteralPath $canonicalExecutable `
+            -Algorithm SHA256).Hash
+        $legacyHash = (Get-FileHash -LiteralPath $legacyExecutable `
+            -Algorithm SHA256).Hash
+        if ($canonicalHash -eq $legacyHash) {
+            [System.IO.File]::Delete($legacyExecutable)
+            Write-Verbose "Removed byte-identical legacy runtime: $legacyExecutable"
+        }
+    } catch {
+        Write-Verbose "Legacy runtime cleanup deferred: $($_.Exception.Message)"
     }
 }
 

--- a/tools/windows/UpdateSupport.ps1
+++ b/tools/windows/UpdateSupport.ps1
@@ -238,8 +238,14 @@ function Expand-Idas3VerifiedUpdatePackage {
     $packageRoots = @(Get-ChildItem -LiteralPath $rootFull -Recurse -File `
         -Filter 'PRODUCT_VERSION.txt' | ForEach-Object {
             $candidate = $_.Directory.FullName
-            if ((Test-Path -LiteralPath (Join-Path $candidate 'demo.exe') `
-                    -PathType Leaf) -and
+            $canonicalRuntime = Join-Path $candidate `
+                'Initial D Arcade Stage 3 Recompiled Runtime.exe'
+            $legacyRuntime = Join-Path $candidate 'demo.exe'
+            $mainLauncher = Join-Path $candidate `
+                'Initial D Arcade Stage 3 Recompiled.exe'
+            if (((Test-Path -LiteralPath $canonicalRuntime -PathType Leaf) -or
+                 (Test-Path -LiteralPath $legacyRuntime -PathType Leaf)) -and
+                (Test-Path -LiteralPath $mainLauncher -PathType Leaf) -and
                 (Test-Path -LiteralPath (Join-Path $candidate 'Play Demo.ps1') `
                     -PathType Leaf)) { $candidate }
         } | Select-Object -Unique)


### PR DESCRIPTION
## Summary
- merge verified update files into existing installs while preserving all user-owned and destination-only data
- standardize the archive folder, root entry point, and native runtime names
- provide a one-release legacy runtime bridge for the updater already shipped in v2457
- prevent complete learned paths from steering from a spatially nearby future switchback

## Verification
- 18 public source checks pass
- updater merge/preservation/rollback/nested-folder checks pass
- moved-launcher and byte-identical legacy migration checks pass without launching the game
- exact v2457-shipped updater and installer successfully transition the actual v2458 archive
- current installer acceptance passes against the actual archive
- private build: ordered-path regression, 34 restart/shutdown, 20 route-parser, 15 controller/music, link-freshness, translation-source, and no-firmware checks pass
- ZIP SHA-256: D2DA3CFA1113E9DDA7DE88C224C4E92DC4E73540C4F44868FBB10E4A6B89CD0F

No live v2458 race run is claimed by this packaging checkpoint. No game data or other private/user-owned content is included.