### PR TITLE
Publish v2459 post-result translation checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v2459-post-result-translation — 2026-09-01
+
+- Accepted the ordered learned-path correction in a bounded Akina Time Attack
+  run: it passed the previous 663.071 m stall, reached 1,488.022 m and a
+  natural result, averaged 60.0 FPS during the race, and generated zero
+  repeated presentation frames.
+- Added the analyzer-verified 0C18FE40 SH-4 helper reached by the post-result
+  card flow. The function covers 28 reachable instructions with one normal
+  return and no unknown opcode or unsafe control edge.
+- Repeated the same bounded route on the v2459 executable. The post-result/card
+  path reported zero recognized untranslated calls or runtime faults, used no
+  forced result, exited cooperatively, and left no game process.
+- Retained the canonical `Initial D Arcade Stage 3 Recompiled` folder, main
+  executable, and runtime names plus merge-based updates. The real v2459
+  archive passed both the current installer and the exact updater/installer
+  shipped in v2457 while preserving user and destination-only data.
+- Passed 18 public source tests, Windows updater and relocated-launcher tests,
+  private path-cache/route/controller/music/shutdown checks, translation and
+  link-freshness verification, and the standalone no-firmware audit.
+
+
 ## v2458-merged-update-naming — 2026-09-01
 
 - Changed fresh archives to contain one top-level folder named

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of *Initial D Arcade Stage 3* (GDS-0033) for modern Windows PCs.
 > not include game data, a BIOS, card saves, custom music, logs, or extracted
 > assets. You must provide your own legally obtained matching game files.
 
-[**Download Public Early Demo v2458 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2458-merged-update-naming)
+[**Download Public Early Demo v2459 for Windows x64**](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2459-post-result-translation)
 
 ![Native intro progress](docs/media/native-intro-full.gif)
 
@@ -29,8 +29,8 @@ PIC only to verify and locally extract the data required by the recompilation.
 
 ## Quick start
 
-1. Download and extract `Initial.D.Arcade.Stage.3.Recompiled.v2458.zip` from
-   the [v2458 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2458-merged-update-naming).
+1. Download and extract `Initial.D.Arcade.Stage.3.Recompiled.v2459.zip` from
+   the [v2459 prerelease](https://github.com/distilledorion-sketch/Initial-D-Arcade-Stage-3-Native-SH-4-Recompilation-WIP-/releases/tag/v2459-post-result-translation).
 2. Place your own matching files in the included `game files` folder:
    - `gds-0033.chd`
    - `317-0384-com.pic`
@@ -42,9 +42,9 @@ Python is not required. Allow roughly 1.3 GB of temporary free space during
 first-run extraction. A NAOMI 2 BIOS is neither required nor accepted.
 
 Public ZIP SHA-256:
-`D2DA3CFA1113E9DDA7DE88C224C4E92DC4E73540C4F44868FBB10E4A6B89CD0F`
+`B42F76F6D15D6CDE1014B94390755F336B263997ADF7AC73ED5F69C9DB39D5B2`
 
-## Current integration progress (v2458 WIP and public early demo)
+## Current integration progress (v2459 WIP and public early demo)
 
 - BIOS-free translated SH-4 boot, menu, race, result, and tested save flows.
 - Vulkan rendering with an authentic 60 Hz mode plus experimental 90/120 Hz
@@ -78,7 +78,7 @@ Public ZIP SHA-256:
   checkbox enables verified automatic installs on future launches. Updates
   preserve game files, cards, music, logs, and user settings and roll back if
   installation fails.
-- v2458 archives extract into one `Initial D Arcade Stage 3 Recompiled`
+- v2459 archives extract into one `Initial D Arcade Stage 3 Recompiled`
   folder. Updates merge into the existing installation: new product files are
   added, versioned product files are replaced, and destination-only files plus
   user data remain untouched. The main entry point is
@@ -198,13 +198,14 @@ Public ZIP SHA-256:
   it, preserved user data, and confirmed that an already-current installation
   is not offered the same update. No live Direct-renderer run is claimed for
   v2457.
-- The v2458 merge/naming checkpoint passed the same complete private build
-  suite plus a parallel-switchback learned-path regression. The actual archive
-  passed isolated new-installer acceptance and an exact v2457-shipped-updater
-  transition: both found the nested product folder, preserved user data and
-  unrelated files, selected the renamed runtime, retired only the
-  byte-identical legacy name, and launched no game process. A live v2458 race
-  run is not claimed by this packaging checkpoint.
+- The v2459 checkpoint passed the complete private build suite plus the
+  parallel-switchback learned-path regression. A bounded Akina Time Attack run
+  passed the old 663.071 m stall, reached 1,488.022 m and a natural result,
+  averaged 60.0 FPS during the race, generated zero repeated presentation
+  frames, and exited cooperatively. The post-result/card flow reported zero
+  recognized untranslated calls or runtime faults. The real archive also
+  passed current-installer and exact-v2457-updater merge acceptances without
+  launching the game.
 - The earlier v2446/schema-5 checkpoint established independent three-field
   direction identity and stopped treating dry/wet condition meshes as road
   direction. The final-v2449 70/70 matrix below supersedes its mixed-build
@@ -269,8 +270,10 @@ failure, and the newest logs. Do not upload game files, extracted assets, card
 data, or copyrighted music.
 
 See [STATUS.md](STATUS.md) for the evidence ledger,
+[the v2459 public checkpoint](docs/CURRENT_CHECKPOINT_V2459_POST_RESULT_TRANSLATION_2026-09-01.md)
+for the latest runtime, updater, naming, and package facts,
 [the v2458 public checkpoint](docs/CURRENT_CHECKPOINT_V2458_MERGED_UPDATE_NAMING_2026-09-01.md)
-for the latest updater, naming, and package facts,
+for the preceding naming-transition facts,
 [the v2457 public checkpoint](docs/CURRENT_CHECKPOINT_V2457_DIRECT_AUTHORITATIVE_2026-09-01.md)
 for the preceding Direct-Vulkan/release facts,
 [the v2456 public checkpoint](docs/CURRENT_CHECKPOINT_V2456_DIRECT_VULKAN_RETRY_2026-09-01.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Work is ordered by the first unresolved hardware boundary. Each milestone has a concrete acceptance gate.
 
-## Current integration checkpoint — v2458 ordered path and merged updates
+## Current integration checkpoint — v2459 post-result translation
 
 - Direct Vulkan presentation bypasses the Safe path's CPU/GDI display boundary
   when explicitly selected.
@@ -40,18 +40,20 @@ Work is ordered by the first unresolved hardware boundary. Each milestone has a 
 - Developer-only persisted Time Attack path capture/playback now has a
   validated binary format and live-control-clock recovery policy. No learned
   input data is published. v2458 prevents a later spatially adjacent
-  switchback from overriding the ordered controller; live validation past the
-  existing 663 m route stall remains an open QA gate.
+  switchback from overriding the ordered controller. A bounded v2459 run
+  passed the old 663.071 m stall, reached 1,488.022 m and a natural result,
+  then crossed the post-result/card flow with zero recognized runtime faults.
 
 Checkpoint result: the newest Direct performance and attract runs are
 host-clean, the cinematic widescreen defect is regression-protected, the
 entire route-state matrix has exact-v2449 movement proof, and nine natural
-rival results now have strict exact-v2453 evidence. v2458 retains the saved
-Direct choice in offline policy tests; a live Direct-renderer acceptance run
-for this exact build is not claimed. Full-race,
+rival results now have strict exact-v2453 evidence. v2459 adds live offscreen
+60 Hz acceptance for the corrected Akina learned path and post-result static
+translation; a live Direct-renderer acceptance run for this exact build is not
+claimed. Full-race,
 cross-driver, car/opponent, campaign, persistence, and visual stress remain.
 
-## Published checkpoint — v2458 public early demo
+## Published checkpoint — v2459 public early demo
 
 - A Windows x64 package now verifies matching user-owned CHD/PIC inputs,
   extracts required data locally, and launches the BIOS-free static-AOT path
@@ -78,7 +80,7 @@ cross-driver, car/opponent, campaign, persistence, and visual stress remain.
   installation, user-data preservation, and current-version suppression in an
   isolated folder without starting the game.
 - The requested folder/main/runtime names and merge semantics pass against the
-  real v2458 archive. An additional acceptance used the exact v2457-shipped
+  real v2459 archive. An additional acceptance used the exact v2457-shipped
   updater and installer, proving existing users can cross the naming change
   while keeping user and destination-only files.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status and evidence ledger
 
 Status date: 2026-09-01
-Integration checkpoint: v2458 WIP
-Public checkpoint: v2458 Windows x64 early-demo prerelease
+Integration checkpoint: v2459 WIP
+Public checkpoint: v2459 Windows x64 early-demo prerelease
 
 This file separates demonstrated behavior from hypotheses. Percentages are deliberately avoided: a technically advanced attract-mode path is not the same thing as a playable game.
 
@@ -19,9 +19,29 @@ This file separates demonstrated behavior from hypotheses. Percentages are delib
 | Card | No-card operation works; a disposable 207-byte card passes insert/load/save/eject/removal/reinsert/reload; selected managed cards use a move-safe path under the local `card data` folder. The post-Bunta result path now waits for the required physical-removal status before queuing the saved card for the next prompt | Real user card data is never used for QA; damaged-card and remaining error branches need coverage |
 | Performance | Authentic 60 Hz guest timing with distinct 120 Hz presentation on measured routes; GPU projection, ELAN lighting, depth normalization, mapped geometry/uniform streams, static topology summaries, and Direct Vulkan display are active. A v2448 2560x1080 Akagi run held 120.0 FPS minimum/average across 21 moving-race samples, produced 240 distinct frames per two-second sample, and added zero repeats; v2441 also reduced the controlled warmed static-reuse frame from 0.696 ms to 0.629 ms median | 120 Hz is experimental; exhaustive content coverage and uncapped presentation are not complete |
 | Host shutdown | Cooperative Vulkan stop request, raster-worker exit handshake, message pumping, join-before-window-destroy order, bounded acquire/fence/startup-upload waits, cooperative QA watchdog, single-instance enforcement, and Direct-session diagnostics pass source/offscreen checks. v2457 treats a saved Direct choice as authoritative: a stale or unavailable diagnostic marker does not prompt or force Safe; Safe remains the first-run default and a manual choice | Repeated live close/restart stress across more GPUs/drivers remains open; no live Direct-renderer run is claimed for v2457 |
-| Distribution | The v2458 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified merge updates. The archive has one canonically named top-level folder; the main executable and native runtime have stable product names | Clean-machine coverage is limited and the release remains unfinished |
+| Distribution | The v2459 BIOS-free, Python-free Windows x64 public early demo accepts only matching user-owned inputs, performs verification/extraction locally, persists the selected Direct/Safe Vulkan path, and checks GitHub for digest-verified merge updates. The archive has one canonically named top-level folder; the main executable and native runtime have stable product names | Clean-machine coverage is limited and the release remains unfinished |
 
 ## Strongest accepted evidence
+
+- v2459 native executable SHA-256:
+  `C31ACF51EFB3DE210381E9754B4D3C702C770EC1CD7258DA2CD663E607CF0C5E`.
+  Its analyzer-verified post-result helper contains 28 reachable SH-4
+  instructions, one normal return, and no unknown opcode or unsafe control
+  edge. Compilation, 34 restart/shutdown policies, 20 route-parser policies,
+  15 controller/music policies, learned-path regression, link freshness, and
+  the standalone no-firmware audit pass.
+- A bounded offscreen v2459 Akina Time Attack run passed the earlier 663.071 m
+  learned-path stall, reached 1,488.022 m and a natural result, and reported
+  race display minimum/average of 59.8/60.0 FPS. It generated no repeated
+  presentation frames, used no forced result, recorded zero recognized errors
+  or runtime faults, exited cooperatively, and left no game process.
+- v2459 public ZIP SHA-256:
+  `B42F76F6D15D6CDE1014B94390755F336B263997ADF7AC73ED5F69C9DB39D5B2`;
+  audited size is 23,813,057 bytes. Its 18 entries contain no game data, BIOS,
+  PIC, cards, music, logs, captures, learned paths, generated guest-code
+  source, or private paths. Current-installer and exact-v2457-updater
+  acceptances both preserved user data, selected the canonical folder/runtime,
+  migrated the byte-identical legacy name, and launched no game process.
 
 - v2458 native executable SHA-256:
   `5636197D7CA5D3DEDEAA2FA7F016A2C6899516D5C8D30A74AD150636E53C49A2`.

--- a/docs/CURRENT_CHECKPOINT_V2459_POST_RESULT_TRANSLATION_2026-09-01.md
+++ b/docs/CURRENT_CHECKPOINT_V2459_POST_RESULT_TRANSLATION_2026-09-01.md
@@ -1,0 +1,46 @@
+# v2459 post-result translation checkpoint — 2026-09-01
+
+This prerelease keeps the stable product identity introduced in v2458 and
+advances the tested static-AOT route through the Akina Time Attack result/card
+transition.
+
+## Runtime acceptance
+
+- Native executable SHA-256:
+  `C31ACF51EFB3DE210381E9754B4D3C702C770EC1CD7258DA2CD663E607CF0C5E`
+- The mechanically verified `0x0C18FE40` guest helper spans 56 bytes, has 28
+  reachable SH-4 instructions, one normal return, no unknown instructions, and
+  no unsafe control-flow edge.
+- A bounded offscreen 640x480 Vulkan run used authentic 60 Hz guest timing,
+  60 FPS presentation, one raster worker, muted audio, and Below Normal process
+  priority. It passed the previous 663.071 m learned-path stall, reached
+  1,488.022 m, and entered a natural game-owned result without outcome
+  injection.
+- Race display minimum/average were 59.8/60.0 FPS. The complete run reported
+  zero repeated presentation frames, zero recognized errors/runtime faults,
+  cooperative exit code 0, and no remaining game process.
+
+This is one targeted route acceptance, not proof that every race, card, or
+error branch is complete.
+
+## Package and updater acceptance
+
+- Archive: `Initial.D.Arcade.Stage.3.Recompiled.v2459.zip`
+- ZIP SHA-256:
+  `B42F76F6D15D6CDE1014B94390755F336B263997ADF7AC73ED5F69C9DB39D5B2`
+- Audited size: 23,813,057 bytes; 18 files.
+- The archive contains one top-level folder named
+  `Initial D Arcade Stage 3 Recompiled`. Its root entry point is
+  `Initial D Arcade Stage 3 Recompiled.exe`; its native helper is
+  `Initial D Arcade Stage 3 Recompiled Runtime.exe`.
+- The real ZIP passed the current merge installer and the exact updater plus
+  installer shipped in v2457. Both accepted version 2459, preserved protected
+  user data and unrelated destination-only files, selected the canonical
+  folder/runtime, and did not launch the game.
+- A byte-identical `demo.exe` compatibility copy remains so pre-v2458 updaters
+  can accept a direct jump to the newest release. The installed launcher
+  removes only that exact duplicate and preserves modified or unrelated files.
+
+The archive contains no game data, BIOS, PIC, CHD, cards, custom music, logs,
+captures, learned paths, generated guest-code source, credentials, or private
+host paths. Users must provide legally obtained matching game inputs locally.

--- a/docs/PUBLIC_PACKAGE.md
+++ b/docs/PUBLIC_PACKAGE.md
@@ -25,7 +25,7 @@
 The Git source package documents and tests the engineering work but cannot boot
 the game by itself. The separate Windows prerelease includes the native runtime
 and local setup tools, but still contains no user-owned game inputs. That
-boundary is intentional. The v2458 public ZIP retains `PRODUCT_VERSION.txt`
+boundary is intentional. The v2459 public ZIP retains `PRODUCT_VERSION.txt`
 and the two updater helpers; it contains 18 audited files in total because one
 byte-identical legacy runtime name is required for the v2457 updater transition.
 Update packages

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -22,7 +22,7 @@ decoder/renderer snapshots refer to support
 headers in the private integration tree and are included for review, not as a
 claim that this repository is a complete runtime.
 
-The private v2458 integration tree has advanced beyond these selected snapshots
+The private v2459 integration tree has advanced beyond these selected snapshots
 with targeted menu-to-race/result/save execution, corrected HUD and mirror
 projection, additional PVR list features, native AICA/Maple/JVS/card tests,
 persistent renderer workers, Vulkan pipeline prewarming, fixed 60 Hz retained

--- a/tests/test_launcher_policy.py
+++ b/tests/test_launcher_policy.py
@@ -67,7 +67,7 @@ class LauncherPolicyTests(unittest.TestCase):
         update_call = LAUNCHER.index("Invoke-Idas3UpdateCheck")
         setup_call = LAUNCHER.index("function Find-GameInputFile")
         self.assertLess(update_call, setup_call)
-        self.assertIn("$ProductVersion = 2458", LAUNCHER)
+        self.assertIn("$ProductVersion = 2459", LAUNCHER)
         self.assertIn("[switch]$SkipUpdateCheck", LAUNCHER)
 
     def test_canonical_main_and_runtime_names_are_migration_safe(self):

--- a/tools/windows/Play Demo.ps1
+++ b/tools/windows/Play Demo.ps1
@@ -58,7 +58,7 @@ trap {
 $handoffRoot = $PSScriptRoot
 $buildRoot = $PSScriptRoot
 $logRoot = Join-Path $PSScriptRoot 'logs'
-$ProductVersion = 2458
+$ProductVersion = 2459
 $canonicalRuntimeName = 'Initial D Arcade Stage 3 Recompiled Runtime.exe'
 $canonicalExecutable = Join-Path $buildRoot $canonicalRuntimeName
 $legacyExecutable = Join-Path $buildRoot 'demo.exe'
@@ -97,10 +97,10 @@ if (-not $ValidateOnly) {
     }
 }
 
-# v2458 is a transition package: it includes the old runtime name so v2457's
-# already-installed updater can verify the archive, plus the canonical name
-# used from this launch onward.  Remove only a byte-identical legacy duplicate;
-# an unrelated or locally modified demo.exe is deliberately preserved.
+# Transition archives include the old runtime name so an updater installed
+# before v2458 can verify the archive, plus the canonical name used from this
+# launch onward. Remove only a byte-identical legacy duplicate; an unrelated
+# or locally modified demo.exe is deliberately preserved.
 if (-not $PSBoundParameters.ContainsKey('Exe') -and
     (Test-Path -LiteralPath $canonicalExecutable -PathType Leaf) -and
     (Test-Path -LiteralPath $legacyExecutable -PathType Leaf)) {


### PR DESCRIPTION
## Summary
- publish the verified v2459 runtime/package checkpoint
- keep the canonical Initial D Arcade Stage 3 Recompiled folder, launcher, and runtime names
- document the bounded Akina learned-path and post-result acceptance
- advance the updater version to 2459

## Verification
- 18 public source tests
- Windows updater acceptance
- relocated launcher acceptance (no game process)
- private build/link/standalone suite
- bounded offscreen route: natural result, 1,488.022 m, race 59.8/60.0 FPS min/avg, zero recognized runtime faults, cooperative exit
- real v2459 ZIP accepted by current installer and exact v2457 updater/installer